### PR TITLE
Revert "Bump ProDotNetZip from 1.18.0 to 1.19.0 in /Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Error.Reporting"

### DIFF
--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Error.Reporting/Krypton.Toolkit.Suite.Extended.Error.Reporting 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Error.Reporting/Krypton.Toolkit.Suite.Extended.Error.Reporting 2022.csproj
@@ -157,7 +157,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Handlebars.Net" Version="2.1.6" />
-		<PackageReference Include="ProDotNetZip" Version="1.19.0" />
+		<PackageReference Include="ProDotNetZip" Version="1.18.0" />
 		<PackageReference Include="Simple-MAPI.NET" Version="1.2.1" />
 		<PackageReference Include="System.Management" Version="9.0.0-rc.2.24473.5" />
 	</ItemGroup>


### PR DESCRIPTION
Reverts Krypton-Suite/Extended-Toolkit#505 due to merge hell