### PR TITLE
* Can't add outlook grid group box control

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -6,6 +6,7 @@
 
 ## 2026-11-xx - Build 2611 - November 2026
 
+* Resolved [#25](https://github.com/Krypton-Suite/Extended-Toolkit/issues/25), Can't add outlook grid group box control - Fixed language-related error when adding `KryptonOutlookGridGroupBox` control in Visual Studio designer. Replaced deprecated `LanguageManager.Instance.GetString()` calls with `KryptonOutlookGridLanguageManager.GeneralStrings` for DateInterval enum localization, eliminating dependency on resource files that could fail with EN/GB language settings.
 * Resolved [#156](https://github.com/Krypton-Suite/Extended-Toolkit/issues/156), `KryptonOutlookGrid` Group Header graphic issue with scaling at 150%
 * Implemented [#511](https://github.com/Krypton-Suite/Extended-Toolkit/issues/511), `KryptonMessageBoxExtended` Expandable Footer Feature
   - **New Expandable Footer** - Similar to Windows TaskDialog, the message box now supports an expandable footer area

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Outlook.Grid/Classes/General/KryptonOutlookGrid.cs
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Outlook.Grid/Classes/General/KryptonOutlookGrid.cs
@@ -1080,6 +1080,24 @@ public partial class KryptonOutlookGrid : KryptonDataGridView
         Fill();
     }
 
+    /// <summary>
+    /// Gets the display text for a DateInterval enum name.
+    /// </summary>
+    /// <param name="intervalName">The name of the DateInterval enum value.</param>
+    /// <returns>The localized display text.</returns>
+    private static string GetDateIntervalDisplayText(string intervalName)
+    {
+        return intervalName switch
+        {
+            nameof(DateInterval.Day) => KryptonOutlookGridLanguageManager.GeneralStrings.Day,
+            nameof(DateInterval.Month) => KryptonOutlookGridLanguageManager.GeneralStrings.Month,
+            nameof(DateInterval.Quarter) => KryptonOutlookGridLanguageManager.GeneralStrings.Quarter,
+            nameof(DateInterval.Year) => KryptonOutlookGridLanguageManager.GeneralStrings.Year,
+            nameof(DateInterval.Smart) => KryptonOutlookGridLanguageManager.GeneralStrings.Smart,
+            _ => intervalName
+        };
+    }
+
     private void OnGroupIntervalClick(object sender, EventArgs e)
     {
         KryptonContextMenuItem? item = (KryptonContextMenuItem)sender;
@@ -1885,7 +1903,8 @@ public partial class KryptonOutlookGrid : KryptonDataGridView
             KryptonContextMenuItemBase[] arrayOptions = new KryptonContextMenuItemBase[names.Length];
             for (int i = 0; i < names.Length; i++)
             {
-                it = new KryptonContextMenuItem(LanguageManager.Instance.GetString(names[i]));
+                string displayText = GetDateIntervalDisplayText(names[i]);
+                it = new KryptonContextMenuItem(displayText);
                 it.Tag = names[i];
                 it.Click += OnGroupIntervalClick;
                 arrayOptions[i] = it;

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Outlook.Grid/User Control/KryptonOutlookGridGroupBox.cs
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Outlook.Grid/User Control/KryptonOutlookGridGroupBox.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  * Use of this source code is governed by a BSD-style
  * license or other governing licenses that can be found in the LICENSE.md file or at
@@ -901,6 +901,24 @@ public partial class KryptonOutlookGridGroupBox : UserControl
 
     #region Methods
 
+    /// <summary>
+    /// Gets the display text for a DateInterval enum name.
+    /// </summary>
+    /// <param name="intervalName">The name of the DateInterval enum value.</param>
+    /// <returns>The localized display text.</returns>
+    private static string GetDateIntervalDisplayText(string intervalName)
+    {
+        return intervalName switch
+        {
+            nameof(DateInterval.Day) => KryptonOutlookGridLanguageManager.GeneralStrings.Day,
+            nameof(DateInterval.Month) => KryptonOutlookGridLanguageManager.GeneralStrings.Month,
+            nameof(DateInterval.Quarter) => KryptonOutlookGridLanguageManager.GeneralStrings.Quarter,
+            nameof(DateInterval.Year) => KryptonOutlookGridLanguageManager.GeneralStrings.Year,
+            nameof(DateInterval.Smart) => KryptonOutlookGridLanguageManager.GeneralStrings.Smart,
+            _ => intervalName
+        };
+    }
+
     /// <summary>Creates the group box.</summary>
     /// <param name="column">The column.</param>
     /// <param name="groupingType">Type of the grouping.</param>
@@ -989,7 +1007,8 @@ public partial class KryptonOutlookGridGroupBox : UserControl
             KryptonContextMenuItemBase[] arrayOptions = new KryptonContextMenuItemBase[names.Length];
             for (int i = 0; i < names.Length; i++)
             {
-                it = new KryptonContextMenuItem(LanguageManager.Instance.GetString(names[i]));
+                string displayText = GetDateIntervalDisplayText(names[i]);
+                it = new KryptonContextMenuItem(displayText);
                 it.Tag = names[i];
                 it.Click += OnGroupIntervalClick;
                 arrayOptions[i] = it;


### PR DESCRIPTION
# Fix: Can't add Outlook Grid Group Box control in Visual Studio designer

## Related Issue
Fixes [#25](https://github.com/Krypton-Suite/Extended-Toolkit/issues/25)

## Description
This PR resolves a language-related error that prevented the `KryptonOutlookGridGroupBox` control from being added to forms in the Visual Studio designer. The issue was caused by the control attempting to use deprecated `LanguageManager.Instance.GetString()` calls for DateInterval enum localization, which could fail when resource files were missing or when using different language settings (EN vs GB).

## Problem
When attempting to add the `KryptonOutlookGridGroupBox` control to a form in Visual Studio designer, an error would occur due to:
- Dependency on the old `LanguageManager.Instance` resource system
- Missing or inaccessible resource files for DateInterval enum values
- Language-specific issues (EN vs GB) causing resource lookup failures
- The error occurred during context menu initialization when creating DateInterval menu items

## Solution
Replaced all `LanguageManager.Instance.GetString()` calls for DateInterval enum localization with the modern `KryptonOutlookGridLanguageManager.GeneralStrings` system that's already used throughout the rest of the Outlook Grid controls.

### Changes Made

1. **KryptonOutlookGridGroupBox.cs**
   - Added `GetDateIntervalDisplayText()` helper method to map DateInterval enum names to localized strings
   - Replaced `LanguageManager.Instance.GetString(names[i])` with `GetDateIntervalDisplayText(names[i])` in the Group Interval menu creation code

2. **KryptonOutlookGrid.cs**
   - Added the same `GetDateIntervalDisplayText()` helper method
   - Replaced `LanguageManager.Instance.GetString(names[i])` with `GetDateIntervalDisplayText(names[i])` in the Group Interval menu creation code

### Implementation Details

The `GetDateIntervalDisplayText()` method uses a switch expression to map DateInterval enum values to their corresponding localized strings:
- `DateInterval.Day` → `KryptonOutlookGridLanguageManager.GeneralStrings.Day`
- `DateInterval.Month` → `KryptonOutlookGridLanguageManager.GeneralStrings.Month`
- `DateInterval.Quarter` → `KryptonOutlookGridLanguageManager.GeneralStrings.Quarter`
- `DateInterval.Year` → `KryptonOutlookGridLanguageManager.GeneralStrings.Year`
- `DateInterval.Smart` → `KryptonOutlookGridLanguageManager.GeneralStrings.Smart`
## 📝 Files Changed
- `Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Outlook.Grid/User Control/KryptonOutlookGridGroupBox.cs`
- `Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Outlook.Grid/Classes/General/KryptonOutlookGrid.cs`
- `Documents/Help/Changelog.md`

## Breaking Changes
None - This is a bug fix that maintains backward compatibility.

## Additional Notes
- This fix aligns with the existing migration from `LanguageManager.Instance` to `KryptonOutlookGridLanguageManager.GeneralStrings` that was already completed for other menu items
- The solution eliminates the dependency on resource files that may not be available in all environments
- The fix ensures consistent localization behavior across all Outlook Grid controls