### PR TITLE
* Alert.ShowMessage should be within the bounds of the parent applica…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,10 @@ jobs:
         with:
           fetch-depth: 0  # Full history for versioning
 
+      # Extended-Toolkit project refs expect Standard-Toolkit as sibling (..\Standard-Toolkit)
+      - name: Checkout Standard-Toolkit
+        run: git clone --depth 1 https://github.com/Krypton-Suite/Standard-Toolkit.git ../Standard-Toolkit
+
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
@@ -70,11 +74,12 @@ jobs:
         with:
           nuget-version: 'latest'
 
+      # Use the non-NuGet solution so projects use ProjectReference to Standard-Toolkit (no Krypton.Standard.Toolkit package on nuget.org)
       - name: Restore NuGet packages
-        run: nuget restore "Source/Krypton Toolkit/Krypton Toolkit Suite Extended 2022 - VS2022 - NuGet.sln"
+        run: nuget restore "Source/Krypton Toolkit/Krypton Toolkit Suite Extended 2022 - VS2022.sln"
 
       - name: Build solution
-        run: msbuild "Source/Krypton Toolkit/Krypton Toolkit Suite Extended 2022 - VS2022 - NuGet.sln" /p:Configuration=${{ matrix.configuration }} /p:Platform="Any CPU" /m /v:minimal
+        run: msbuild "Source/Krypton Toolkit/Krypton Toolkit Suite Extended 2022 - VS2022.sln" /p:Configuration=${{ matrix.configuration }} /p:Platform="Any CPU" /m /v:minimal
 
       - name: Upload build artifacts
         if: matrix.configuration != 'Debug'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,42 +21,67 @@ jobs:
         configuration: [Debug, Release, ReleaseLite, Canary, CanaryLite, Nightly, NightlyLite]
     
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0  # Full history for versioning
-    
-    - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: |
-          10.0.x
-          9.0.x
-          8.0.x
-          6.0.x
-    
-    - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v2
-      with:
-        vs-version: 'latest'
-    
-    - name: Setup NuGet
-      uses: NuGet/setup-nuget@v2
-      with:
-        nuget-version: 'latest'
-    
-    - name: Restore NuGet packages
-      run: nuget restore "Source/Krypton Toolkit/Krypton Toolkit Suite Extended 2022 - VS2022 - NuGet.sln"
-    
-    - name: Build solution
-      run: msbuild "Source/Krypton Toolkit/Krypton Toolkit Suite Extended 2022 - VS2022 - NuGet.sln" /p:Configuration=${{ matrix.configuration }} /p:Platform="Any CPU" /m /v:minimal
-    
-    - name: Upload build artifacts
-      if: matrix.configuration != 'Debug'
-      uses: actions/upload-artifact@v4
-      with:
-        name: Build-${{ matrix.configuration }}
-        path: |
-          Bin/${{ matrix.configuration }}/
-        retention-days: 7
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for versioning
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            10.0.x
+            9.0.x
+            8.0.x
+            6.0.x
+
+      # .NET 11 (Preview)
+      - name: Setup .NET 11 (Preview)
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 11.0.x
+          dotnet-quality: preview
+
+      # global.json dynamically generate (use latest SDK available)
+      - name: Force .NET 11 SDK via global.json
+        run: |
+          $sdkVersion = (dotnet --list-sdks | Select-String "11.0").ToString().Split(" ")[0]
+          if (-not $sdkVersion) {
+            # Fallback to .NET 10 if .NET 11 is not available
+            $sdkVersion = (dotnet --list-sdks | Select-String "10.0").ToString().Split(" ")[0]
+          }
+          Write-Output "Using SDK $sdkVersion"
+          @"
+          {
+            "sdk": {
+              "version": "$sdkVersion",
+              "rollForward": "latestFeature"
+            }
+          }
+          "@ | Out-File -Encoding utf8 global.json
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+        with:
+          vs-version: 'latest'
+
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v2
+        with:
+          nuget-version: 'latest'
+
+      - name: Restore NuGet packages
+        run: nuget restore "Source/Krypton Toolkit/Krypton Toolkit Suite Extended 2022 - VS2022 - NuGet.sln"
+
+      - name: Build solution
+        run: msbuild "Source/Krypton Toolkit/Krypton Toolkit Suite Extended 2022 - VS2022 - NuGet.sln" /p:Configuration=${{ matrix.configuration }} /p:Platform="Any CPU" /m /v:minimal
+
+      - name: Upload build artifacts
+        if: matrix.configuration != 'Debug'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Build-${{ matrix.configuration }}
+          path: |
+            Bin/${{ matrix.configuration }}/
+          retention-days: 7
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,171 +30,195 @@ jobs:
     runs-on: windows-latest
     
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0  # Full history for versioning
-    
-    - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: |
-          10.0.x
-          9.0.x
-          8.0.x
-          6.0.x
-       # continue-on-error: true
-        
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for versioning
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            10.0.x
+            9.0.x
+            8.0.x
+            6.0.x
+          # continue-on-error: true
+
+      # .NET 11 (Preview)
+      - name: Setup .NET 11 (Preview)
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 11.0.x
+          dotnet-quality: preview
+
+      - name: Force .NET 11 SDK via global.json  # global.json dynamically generated
+        run: |
+          $sdkVersion = (dotnet --list-sdks | Select-String "11.0").ToString().Split(" ")[0]
+          if (-not $sdkVersion) {
+            # Fallback to .NET 10 if .NET 11 is not available
+            $sdkVersion = (dotnet --list-sdks | Select-String "10.0").ToString().Split(" ")[0]
+          }
+          Write-Output "Using SDK $sdkVersion"
+          @"
+          {
+            "sdk": {
+              "version": "$sdkVersion",
+              "rollForward": "latestFeature"
+            }
+          }
+          "@ | Out-File -Encoding utf8 global.json
+
       - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v2
-      with:
-        vs-version: 'latest'
-    
-    - name: Setup NuGet
-      uses: NuGet/setup-nuget@v2
-      with:
-        nuget-version: 'latest'
-    
-    - name: Determine Configuration
-      id: config
-      shell: pwsh
-      run: |
-        if ("${{ github.event_name }}" -eq "workflow_dispatch") {
-          $config = "${{ inputs.configuration }}"
-        } else {
-          # For tag pushes, determine configuration from tag name or default to Release
-          $config = "Release"
-        }
-        echo "configuration=$config" >> $env:GITHUB_OUTPUT
-        echo "Building with configuration: $config"
-    
-    - name: Restore NuGet packages (Main Solution)
-      run: nuget restore "Source/Krypton Toolkit/Krypton Toolkit Suite Extended 2022 - VS2022.sln"
-    
-    - name: Build Main Solution
-      run: msbuild "Source/Krypton Toolkit/Krypton Toolkit Suite Extended 2022 - VS2022.sln" /p:Configuration=${{ steps.config.outputs.configuration }} /p:Platform="Any CPU" /m /v:minimal
-    
-    - name: Restore NuGet packages (NuGet Solution)
-      run: nuget restore "Source/Krypton Toolkit/Krypton Toolkit Suite Extended 2022 - VS2022 - NuGet.sln"
-    
-    - name: Build NuGet Solution
-      run: msbuild "Source/Krypton Toolkit/Krypton Toolkit Suite Extended 2022 - VS2022 - NuGet.sln" /p:Configuration=${{ steps.config.outputs.configuration }} /p:Platform="Any CPU" /m /v:minimal
-    
-    - name: Build and Pack Ultimate Packages
-      shell: pwsh
-      run: |
-        $config = "${{ steps.config.outputs.configuration }}"
-        $outputDir = "Bin/NuGet Packages/$config"
-        
-        # Ultimate Package
-        $ultimateProject = "Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Ultimate/Krypton.Toolkit.Suite.Extended.Ultimate 2022.csproj"
-        if (Test-Path $ultimateProject) {
-          Write-Host "Building and packing Ultimate package..."
-          dotnet pack $ultimateProject --configuration $config --output $outputDir /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
-        } else {
-          Write-Warning "Ultimate package project not found at: $ultimateProject"
-        }
-        
-        # Ultimate.Lite Package  
-        $ultimateLiteProject = "Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Ultimate.Lite/Krypton.Toolkit.Suite.Extended.Ultimate.Lite 2022.csproj"
-        if (Test-Path $ultimateLiteProject) {
-          Write-Host "Building and packing Ultimate.Lite package..."
-          dotnet pack $ultimateLiteProject --configuration $config --output $outputDir /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
-        } else {
-          Write-Warning "Ultimate.Lite package project not found at: $ultimateLiteProject"
-        }
-    
-    - name: Pack NuGet packages
-      shell: pwsh
-      run: |
-        $config = "${{ steps.config.outputs.configuration }}"
-        
-        # Find all .csproj files and pack them
-        # Note: Directory.Build.targets automatically configures all projects to include referenced binaries
-        Get-ChildItem -Path "Source/Krypton Toolkit" -Filter "*.csproj" -Recurse | ForEach-Object {
-          $project = $_.FullName
-          $projectName = $_.Name
-          
-          # Skip application projects (not libraries) and Ultimate packages (already packed)
-          if ($projectName -like "*Examples*" -or 
-              $projectName -like "*ZipExtractor*" -or 
-              $projectName -like "*AutoUpdateCreator*" -or
-              $projectName -like "*Ultimate*") {
-            Write-Host "Skipping: $projectName"
-            return
+        uses: microsoft/setup-msbuild@v2
+        with:
+          vs-version: 'latest'
+
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v2
+        with:
+          nuget-version: 'latest'
+
+      - name: Determine Configuration
+        id: config
+        shell: pwsh
+        run: |
+          if ("${{ github.event_name }}" -eq "workflow_dispatch") {
+            $config = "${{ inputs.configuration }}"
+          } else {
+            # For tag pushes, determine configuration from tag name or default to Release
+            $config = "Release"
           }
-          
-          Write-Host "Packing: $project"
-          
-          # Pack (settings are applied from Directory.Build.targets)
-          dotnet pack $project --configuration $config --no-build --output "Bin/NuGet Packages/$config"
-        }
-        
-        # Verify the Ultimate packages were created
-        $ultimatePackages = Get-ChildItem -Path "Bin/NuGet Packages/$config" -Filter "*Ultimate*.nupkg" -Exclude "*.symbols.nupkg"
-        if ($ultimatePackages) {
-          Write-Host "`n✅ Ultimate packages created successfully:"
-          foreach ($pkg in $ultimatePackages) {
-            Write-Host "   - $($pkg.Name) ($([math]::Round($pkg.Length / 1MB, 2)) MB)"
+          echo "configuration=$config" >> $env:GITHUB_OUTPUT
+          echo "Building with configuration: $config"
+
+      - name: Restore NuGet packages (Main Solution)
+        run: nuget restore "Source/Krypton Toolkit/Krypton Toolkit Suite Extended 2022 - VS2022.sln"
+
+      - name: Build Main Solution
+        run: msbuild "Source/Krypton Toolkit/Krypton Toolkit Suite Extended 2022 - VS2022.sln" /p:Configuration=${{ steps.config.outputs.configuration }} /p:Platform="Any CPU" /m /v:minimal
+
+      - name: Restore NuGet packages (NuGet Solution)
+        run: nuget restore "Source/Krypton Toolkit/Krypton Toolkit Suite Extended 2022 - VS2022 - NuGet.sln"
+
+      - name: Build NuGet Solution
+        run: msbuild "Source/Krypton Toolkit/Krypton Toolkit Suite Extended 2022 - VS2022 - NuGet.sln" /p:Configuration=${{ steps.config.outputs.configuration }} /p:Platform="Any CPU" /m /v:minimal
+
+      - name: Build and Pack Ultimate Packages
+        shell: pwsh
+        run: |
+          $config = "${{ steps.config.outputs.configuration }}"
+          $outputDir = "Bin/NuGet Packages/$config"
+
+          # Ultimate Package
+          $ultimateProject = "Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Ultimate/Krypton.Toolkit.Suite.Extended.Ultimate 2022.csproj"
+          if (Test-Path $ultimateProject) {
+            Write-Host "Building and packing Ultimate package..."
+            dotnet pack $ultimateProject --configuration $config --output $outputDir /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
+          } else {
+            Write-Warning "Ultimate package project not found at: $ultimateProject"
           }
-        } else {
-          Write-Warning "⚠️ No Ultimate packages were found!"
-        }
-    
-    - name: List NuGet packages
-      shell: pwsh
-      run: |
-        $config = "${{ steps.config.outputs.configuration }}"
-        $nugetDir = "Bin/NuGet Packages/$config"
-        if (Test-Path $nugetDir) {
-          Write-Host "NuGet packages in $nugetDir:"
-          Get-ChildItem -Path $nugetDir -Filter "*.nupkg" | ForEach-Object {
-            Write-Host "  - $($_.Name)"
+
+          # Ultimate.Lite Package
+          $ultimateLiteProject = "Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Ultimate.Lite/Krypton.Toolkit.Suite.Extended.Ultimate.Lite 2022.csproj"
+          if (Test-Path $ultimateLiteProject) {
+            Write-Host "Building and packing Ultimate.Lite package..."
+            dotnet pack $ultimateLiteProject --configuration $config --output $outputDir /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
+          } else {
+            Write-Warning "Ultimate.Lite package project not found at: $ultimateLiteProject"
           }
-        } else {
-          Write-Host "No NuGet packages directory found at: $nugetDir"
-        }
-    
-    - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: Release-${{ steps.config.outputs.configuration }}
-        path: |
-          Bin/${{ steps.config.outputs.configuration }}/
-          Bin/NuGet Packages/${{ steps.config.outputs.configuration }}/
-        retention-days: 30
-    
-    - name: Publish to NuGet.org
-      if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || (github.event_name == 'workflow_dispatch' && inputs.publish_nuget)
-      shell: pwsh
-      env:
-        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-      run: |
-        $config = "${{ steps.config.outputs.configuration }}"
-        $nugetDir = "Bin/NuGet Packages/$config"
-        
-        if (-not (Test-Path $nugetDir)) {
-          Write-Error "NuGet packages directory not found: $nugetDir"
-          exit 1
-        }
-        
-        # Push all .nupkg files (excluding symbol packages which are uploaded automatically)
-        Get-ChildItem -Path $nugetDir -Filter "*.nupkg" -Exclude "*.symbols.nupkg" | ForEach-Object {
-          $package = $_.FullName
-          Write-Host "Publishing: $package"
-          dotnet nuget push $package --api-key $env:NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate
-        }
-    
-    - name: Create GitHub Release
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-      uses: softprops/action-gh-release@v2
-      with:
-        files: |
-          Bin/NuGet Packages/${{ steps.config.outputs.configuration }}/*.nupkg
-          Bin/NuGet Packages/${{ steps.config.outputs.configuration }}/*.snupkg
-        draft: false
-        prerelease: ${{ contains(steps.config.outputs.configuration, 'Canary') || contains(steps.config.outputs.configuration, 'Nightly') }}
-        generate_release_notes: true
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pack NuGet packages
+        shell: pwsh
+        run: |
+          $config = "${{ steps.config.outputs.configuration }}"
+
+          # Find all .csproj files and pack them
+          # Note: Directory.Build.targets automatically configures all projects to include referenced binaries
+          Get-ChildItem -Path "Source/Krypton Toolkit" -Filter "*.csproj" -Recurse | ForEach-Object {
+            $project = $_.FullName
+            $projectName = $_.Name
+
+            # Skip application projects (not libraries) and Ultimate packages (already packed)
+            if ($projectName -like "*Examples*" -or
+                $projectName -like "*ZipExtractor*" -or
+                $projectName -like "*AutoUpdateCreator*" -or
+                $projectName -like "*Ultimate*") {
+              Write-Host "Skipping: $projectName"
+              return
+            }
+
+            Write-Host "Packing: $project"
+
+            # Pack (settings are applied from Directory.Build.targets)
+            dotnet pack $project --configuration $config --no-build --output "Bin/NuGet Packages/$config"
+          }
+
+          # Verify the Ultimate packages were created
+          $ultimatePackages = Get-ChildItem -Path "Bin/NuGet Packages/$config" -Filter "*Ultimate*.nupkg" -Exclude "*.symbols.nupkg"
+          if ($ultimatePackages) {
+            Write-Host "`n✅ Ultimate packages created successfully:"
+            foreach ($pkg in $ultimatePackages) {
+              Write-Host "   - $($pkg.Name) ($([math]::Round($pkg.Length / 1MB, 2)) MB)"
+            }
+          } else {
+            Write-Warning "⚠️ No Ultimate packages were found!"
+          }
+
+      - name: List NuGet packages
+        shell: pwsh
+        run: |
+          $config = "${{ steps.config.outputs.configuration }}"
+          $nugetDir = "Bin/NuGet Packages/$config"
+          if (Test-Path $nugetDir) {
+            Write-Host "NuGet packages in $nugetDir:"
+            Get-ChildItem -Path $nugetDir -Filter "*.nupkg" | ForEach-Object {
+              Write-Host "  - $($_.Name)"
+            }
+          } else {
+            Write-Host "No NuGet packages directory found at: $nugetDir"
+          }
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Release-${{ steps.config.outputs.configuration }}
+          path: |
+            Bin/${{ steps.config.outputs.configuration }}/
+            Bin/NuGet Packages/${{ steps.config.outputs.configuration }}/
+          retention-days: 30
+
+      - name: Publish to NuGet.org
+        if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || (github.event_name == 'workflow_dispatch' && inputs.publish_nuget)
+        shell: pwsh
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          $config = "${{ steps.config.outputs.configuration }}"
+          $nugetDir = "Bin/NuGet Packages/$config"
+
+          if (-not (Test-Path $nugetDir)) {
+            Write-Error "NuGet packages directory not found: $nugetDir"
+            exit 1
+          }
+
+          # Push all .nupkg files (excluding symbol packages which are uploaded automatically)
+          Get-ChildItem -Path $nugetDir -Filter "*.nupkg" -Exclude "*.symbols.nupkg" | ForEach-Object {
+            $package = $_.FullName
+            Write-Host "Publishing: $package"
+            dotnet nuget push $package --api-key $env:NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate
+          }
+
+      - name: Create GitHub Release
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            Bin/NuGet Packages/${{ steps.config.outputs.configuration }}/*.nupkg
+            Bin/NuGet Packages/${{ steps.config.outputs.configuration }}/*.snupkg
+          draft: false
+          prerelease: ${{ contains(steps.config.outputs.configuration, 'Canary') || contains(steps.config.outputs.configuration, 'Nightly') }}
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -6,6 +6,11 @@
 
 ## 2026-11-xx - Build 2611 - November 2026
 
+* Resolved [#56](https://github.com/Krypton-Suite/Extended-Toolkit/issues/56), Alert.ShowMessage should be within the bounds of the parent application
+  - **Positioning Fix** - Alerts now appear within the parent application bounds instead of the primary screen bottom-right (fixes unnoticed alerts on 4K monitors or RDP sessions when the app is in a small window)
+  - **Optional Owner Parameter** - All `Alert` methods now accept an optional `IWin32Window? owner` parameter for explicit parent binding
+  - **Smart Fallback** - When no owner is passed, uses `Form.ActiveForm` when available for improved default behavior
+  - **Proper Ownership** - Sets form `Owner` when a Form is passed, ensuring correct z-order and window relationship
 * Resolved [#411](https://github.com/Krypton-Suite/Extended-Toolkit/issues/411), Exapanding a TreeGridView Node takes a long time when there are many children
   - **Performance Optimization** - Significantly improved expansion/collapse performance for nodes with many children (250+ nodes)
   - **Batch Operations** - Replaced individual row insertions/removals with optimized batch operations

--- a/Source/Documentation/Extended Toolkit API Documentation/Extended Toolkit API Documentation.shfbproj
+++ b/Source/Documentation/Extended Toolkit API Documentation/Extended Toolkit API Documentation.shfbproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Import the common properties to support NuGet restore -->
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -144,8 +144,10 @@
   </ItemGroup>
   <!-- Import the common build targets during NuGet restore because before the packages are being installed, $(SHFBROOT) is not set yet -->
   <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" Condition="'$(MSBuildRestoreSessionId)' != ''" />
-  <!-- Import the SHFB build targets during build -->
-  <Import Project="$(SHFBROOT)\SandcastleHelpFileBuilder.targets" Condition="'$(MSBuildRestoreSessionId)' == ''" />
+  <!-- Import the SHFB build targets during build (only when SHFB is installed; skip in CI/restore when SHFBROOT is not set) -->
+  <Import Project="$(SHFBROOT)\SandcastleHelpFileBuilder.targets" Condition="'$(MSBuildRestoreSessionId)' == '' and '$(SHFBROOT)' != ''" />
+  <!-- When SHFB is not installed (e.g. CI), import common targets so the project still loads and restore succeeds -->
+  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" Condition="'$(MSBuildRestoreSessionId)' == '' and '$(SHFBROOT)' == ''" />
   <!-- The pre-build and post-build event properties must appear *after* the targets file import in order to be
 			 evaluated correctly. -->
   <PropertyGroup>

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Notifications/Classes/Alternative/Alert.cs
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Notifications/Classes/Alternative/Alert.cs
@@ -1,4 +1,4 @@
-﻿#region MIT License
+#region MIT License
 /*
  * MIT License
  *
@@ -45,13 +45,14 @@ public class Alert
     /// <summary>Displays a success message.</summary>
     /// <param name="message">The message.</param>
     /// <param name="headerText">The header text.</param>
-    public static void DisplaySuccessMessage(string message, string? headerText = null) => DisplaySuccessMessage(message, IntervalDefault, headerText);
+    /// <param name="owner">Optional parent window. When provided, the alert is positioned within the owner's bounds and owned by it.</param>
+    public static void DisplaySuccessMessage(string message, string? headerText = null, IWin32Window? owner = null) => DisplaySuccessMessage(message, IntervalDefault, headerText, owner);
 
-    private static void DisplaySuccessMessage(string message, int interval, string? headerText = null)
+    private static void DisplaySuccessMessage(string message, int interval, string? headerText = null, IWin32Window? owner = null)
     {
         KryptonAlertWindow alertWindow = new KryptonAlertWindow();
 
-        alertWindow.DisplayAlert(message, AlertType.Success, interval, headerText: headerText);
+        alertWindow.DisplayAlert(message, AlertType.Success, interval, headerText: headerText, owner: owner);
     }
     #endregion
 
@@ -60,13 +61,14 @@ public class Alert
     /// <summary>Shows a information message.</summary>
     /// <param name="message">The message.</param>
     /// <param name="headerText">The header text.</param>
-    public static void ShowInformationMessage(string message, string? headerText = null) => ShowInformationMessage(message, IntervalDefault, headerText);
+    /// <param name="owner">Optional parent window. When provided, the alert is positioned within the owner's bounds and owned by it.</param>
+    public static void ShowInformationMessage(string message, string? headerText = null, IWin32Window? owner = null) => ShowInformationMessage(message, IntervalDefault, headerText, owner);
 
-    private static void ShowInformationMessage(string message, int interval, string? headerText = null)
+    private static void ShowInformationMessage(string message, int interval, string? headerText = null, IWin32Window? owner = null)
     {
         KryptonAlertWindow alertWindow = new KryptonAlertWindow();
 
-        alertWindow.DisplayAlert(message, AlertType.Information, interval, headerText: headerText);
+        alertWindow.DisplayAlert(message, AlertType.Information, interval, headerText: headerText, owner: owner);
     }
 
     #endregion
@@ -76,13 +78,14 @@ public class Alert
     /// <summary>Shows a warning message.</summary>
     /// <param name="message">The message.</param>
     /// <param name="headerText">The header text.</param>
-    public static void ShowWarningMessage(string message, string? headerText = null) => ShowWarningMessage(message, IntervalDefault, headerText);
+    /// <param name="owner">Optional parent window. When provided, the alert is positioned within the owner's bounds and owned by it.</param>
+    public static void ShowWarningMessage(string message, string? headerText = null, IWin32Window? owner = null) => ShowWarningMessage(message, IntervalDefault, headerText, owner);
 
-    private static void ShowWarningMessage(string message, int interval, string? headerText = null)
+    private static void ShowWarningMessage(string message, int interval, string? headerText = null, IWin32Window? owner = null)
     {
         KryptonAlertWindow alertWindow = new KryptonAlertWindow();
 
-        alertWindow.DisplayAlert(message, AlertType.Warning, interval, headerText: headerText);
+        alertWindow.DisplayAlert(message, AlertType.Warning, interval, headerText: headerText, owner: owner);
     }
 
     #endregion
@@ -92,13 +95,14 @@ public class Alert
     /// <summary>Shows a error message.</summary>
     /// <param name="message">The message.</param>
     /// <param name="headerText">The header text.</param>
-    public static void ShowErrorMessage(string message, string? headerText = null) => ShowErrorMessage(message, IntervalDefault, headerText);
+    /// <param name="owner">Optional parent window. When provided, the alert is positioned within the owner's bounds and owned by it.</param>
+    public static void ShowErrorMessage(string message, string? headerText = null, IWin32Window? owner = null) => ShowErrorMessage(message, IntervalDefault, headerText, owner);
 
-    private static void ShowErrorMessage(string message, int interval, string? headerText = null)
+    private static void ShowErrorMessage(string message, int interval, string? headerText = null, IWin32Window? owner = null)
     {
         KryptonAlertWindow alertWindow = new KryptonAlertWindow();
 
-        alertWindow.DisplayAlert(message, AlertType.Error, interval, headerText: headerText);
+        alertWindow.DisplayAlert(message, AlertType.Error, interval, headerText: headerText, owner: owner);
     }
 
     #endregion
@@ -111,13 +115,14 @@ public class Alert
     /// <param name="backColour">The back colour.</param>
     /// <param name="textColour">The text colour.</param>
     /// <param name="headerText">The header text.</param>
-    public static void ShowCustomMessage(string message, Image? image = null, Color backColour = default, Color textColour = default, string? headerText = null) => ShowCustomMessage(message, IntervalDefault, image, backColour, textColour, headerText);
+    /// <param name="owner">Optional parent window. When provided, the alert is positioned within the owner's bounds and owned by it.</param>
+    public static void ShowCustomMessage(string message, Image? image = null, Color backColour = default, Color textColour = default, string? headerText = null, IWin32Window? owner = null) => ShowCustomMessage(message, IntervalDefault, image, backColour, textColour, headerText, owner);
 
-    private static void ShowCustomMessage(string message, int interval, Image? image = null, Color backColour = default, Color textColour = default, string? headerText = null)
+    private static void ShowCustomMessage(string message, int interval, Image? image = null, Color backColour = default, Color textColour = default, string? headerText = null, IWin32Window? owner = null)
     {
         KryptonAlertWindow alertWindow = new KryptonAlertWindow();
 
-        alertWindow.DisplayAlert(message, AlertType.Custom, interval, image, backColour == default ? Color.FromArgb(83, 92, 104) : backColour, textColour == default ? Color.White : textColour, headerText);
+        alertWindow.DisplayAlert(message, AlertType.Custom, interval, image, backColour == default ? Color.FromArgb(83, 92, 104) : backColour, textColour == default ? Color.White : textColour, headerText, owner);
     }
 
     #endregion


### PR DESCRIPTION
…tion

# Fix: Alert.ShowMessage within bounds of parent application

Fixes [#56](https://github.com/Krypton-Suite/Extended-Toolkit/issues/56)

## Problem

When calling `Alert.ShowMessage` (and related methods) on a small application window positioned in the top-left of a 4K monitor, the notification appeared in the bottom-right of the primary screen—far from the application. Users often missed alerts, especially in RDP sessions with scrolling client views.

## Solution

- **Position alerts relative to the parent** – Alerts now appear within the bounds of the owning form instead of the primary screen.
- **Optional owner parameter** – All `Alert` methods accept an optional `IWin32Window? owner` for explicit parent binding.
- **Improved fallback** – When no owner is passed, uses `Form.ActiveForm` when available.
- **Form ownership** – Sets the alert form’s `Owner` when a `Form` is provided for correct z-order and ownership.

## Changes

### `KryptonAlertWindow.cs`

- Added optional `IWin32Window? owner` parameter to `DisplayAlert()`.
- Introduced `GetReferenceBounds()` helper that:
  - Uses owner bounds when provided (Form, Control, or IWin32Window).
  - Falls back to `Form.ActiveForm` when available.
  - Falls back to `Screen.PrimaryScreen.WorkingArea` otherwise.
- Positions alerts in the bottom-right of the reference bounds with stacking.
- Clamps position for small windows.
- Sets `Owner` when the owner is a `Form`.

### `Alert.cs`

- Added optional `IWin32Window? owner` parameter to:
  - `DisplaySuccessMessage()`
  - `ShowInformationMessage()`
  - `ShowWarningMessage()`
  - `ShowErrorMessage()`
  - `ShowCustomMessage()`

## Usage

**With explicit owner (recommended):**

```csharp
// From within a Form
Alert.ShowInformationMessage("Operation complete!", owner: this);

// Pass a specific control - uses its parent form's bounds
Alert.ShowWarningMessage("Check your input", owner: myTextBox);
```

**Without owner (unchanged API, improved behavior):**

```csharp
Alert.ShowInformationMessage("Done!");
// Uses Form.ActiveForm when available, otherwise primary screen
```

## Backward compatibility

- All new parameters are optional and default to `null`.
- Existing calls continue to work; behavior improves when an active form exists.