### PR TITLE
* Alert.ShowMessage should take an optional Header / title message

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -6,6 +6,9 @@
 
 ## 2026-11-xx - Build 2611 - November 2026
 
+* Implemented [#57](https://github.com/Krypton-Suite/Extended-Toolkit/issues/57), `Alert.ShowMessage` optional header/title
+  - **New API** - `Alert.ShowMessage(string message, string? headerText = null)` shows a message with an optional header or title
+  - When `headerText` is provided, the alert displays the header in bold with the message below; when omitted, only the message is shown (same behaviour as existing typed methods)
 * Resolved [#411](https://github.com/Krypton-Suite/Extended-Toolkit/issues/411), Exapanding a TreeGridView Node takes a long time when there are many children
   - **Performance Optimization** - Significantly improved expansion/collapse performance for nodes with many children (250+ nodes)
   - **Batch Operations** - Replaced individual row insertions/removals with optimized batch operations

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Notifications/Classes/Alternative/Alert.cs
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Notifications/Classes/Alternative/Alert.cs
@@ -1,4 +1,4 @@
-﻿#region MIT License
+#region MIT License
 /*
  * MIT License
  *
@@ -39,6 +39,13 @@ public class Alert
 
     #region Read Only
     private static readonly int IntervalDefault = 1850;
+    #endregion
+
+    #region ShowMessage
+    /// <summary>Shows a message with an optional header/title.</summary>
+    /// <param name="message">The message text.</param>
+    /// <param name="headerText">Optional header or title text.</param>
+    public static void ShowMessage(string message, string? headerText = null) => ShowInformationMessage(message, headerText);
     #endregion
 
     #region Success


### PR DESCRIPTION
# Feature: Alert.ShowMessage with optional header/title

## Issue

Implements [#57](https://github.com/Krypton-Suite/Extended-Toolkit/issues/57) – [Feature Request]: Alert.ShowMessage should take an optional Header / title message.

Users requested a single `Alert.ShowMessage` API that can display a message with an optional header or title.

## Solution

Added a new public method to the `Alert` class:

- **`Alert.ShowMessage(string message, string? headerText = null)`**

The method delegates to the existing `ShowInformationMessage` infrastructure, which already supports optional header text and uses `KryptonAlertWindow.DisplayAlert()`. When `headerText` is provided, the alert shows the header in bold with the message below; when omitted, only the message is shown (same layout behaviour as the existing typed methods).

## Changes

| File | Change |
|------|--------|
| `Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Notifications/Classes/Alternative/Alert.cs` | Added `#region ShowMessage` with `ShowMessage(string message, string? headerText = null)` | | `Documents/Help/Changelog.md` | Added entry for [#57](https://github.com/Krypton-Suite/Extended-Toolkit/issues/57) under 2026-11-xx release |

## Usage

```csharp
// Message only (no header)
Alert.ShowMessage("Operation completed.");

// Message with optional header/title
Alert.ShowMessage("Your changes have been saved.", "Success");
Alert.ShowMessage("Connection timed out.", "Warning");
```

## Testing

- Call `Alert.ShowMessage("Hello")` – alert shows message only.
- Call `Alert.ShowMessage("Saved.", "Success")` – alert shows bold header "Success" and message "Saved." below.
- Confirm styling matches existing Information alerts (icon, colours, timeout).

## Changelog

Changelog entry added in `Documents/Help/Changelog.md` under the 2026-11-xx release section.