### PR TITLE
* Improve MSBuild detection in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,9 +26,10 @@ jobs:
         with:
           fetch-depth: 0  # Full history for versioning
 
-      # Extended-Toolkit project refs expect Standard-Toolkit as sibling (..\Standard-Toolkit)
+      # Extended-Toolkit V110 project refs expect Standard-Toolkit alpha as sibling (..\Standard-Toolkit).
+      # master still uses Krypton.Utilities; alpha renamed it to Krypton.Toolkit.Utilities.
       - name: Checkout Standard-Toolkit
-        run: git clone --depth 1 https://github.com/Krypton-Suite/Standard-Toolkit.git ../Standard-Toolkit
+        run: git clone --depth 1 --branch alpha https://github.com/Krypton-Suite/Standard-Toolkit.git ../Standard-Toolkit
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,13 +32,20 @@ jobs:
         run: git clone --depth 1 --branch alpha https://github.com/Krypton-Suite/Standard-Toolkit.git ../Standard-Toolkit
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: |
             10.0.x
             9.0.x
             8.0.x
             6.0.x
+
+      # Required for net11.0-windows TFMs (Directory.Build.props). Preview until .NET 11 RTM.
+      - name: Setup .NET 11
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: 11.0.x
+          dotnet-quality: preview
 
       - name: Print diagnostics
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     name: Build Toolkit
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     
     strategy:
       matrix:
@@ -65,11 +65,15 @@ jobs:
           "@ | Out-File -Encoding utf8 global.json
 
       - name: Print diagnostics
+        shell: pwsh
         run: |
           dotnet --list-sdks
           dotnet --info
-          $msbuild = Get-ChildItem "C:\Program Files\Microsoft Visual Studio\2022\*\MSBuild\Current\Bin\MSBuild.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
-          if ($msbuild) { & $msbuild.FullName -version } else { msbuild -version 2>$null; if (-not $?) { Write-Output "msbuild not found (using dotnet build instead)" } }
+          if (Get-Command msbuild -ErrorAction SilentlyContinue) {
+            msbuild -version
+          } else {
+            Write-Output "msbuild not found (using dotnet build instead)"
+          }
 
       # Use the non-NuGet solution so projects use ProjectReference to Standard-Toolkit (no Krypton.Standard.Toolkit package on nuget.org)
       - name: Restore using dotnet

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,8 @@ jobs:
         run: |
           dotnet --list-sdks
           dotnet --info
-          & 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe' -version || msbuild -version || Write-Output "msbuild not found"
+          $msbuild = Get-ChildItem "C:\Program Files\Microsoft Visual Studio\2022\*\MSBuild\Current\Bin\MSBuild.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+          if ($msbuild) { & $msbuild.FullName -version } else { msbuild -version 2>$null; if (-not $?) { Write-Output "msbuild not found (using dotnet build instead)" } }
 
       # Use the non-NuGet solution so projects use ProjectReference to Standard-Toolkit (no Krypton.Standard.Toolkit package on nuget.org)
       - name: Restore using dotnet

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,31 +40,6 @@ jobs:
             8.0.x
             6.0.x
 
-      # .NET 11 (Preview)
-      - name: Setup .NET 11 (Preview)
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: 11.0.x
-          dotnet-quality: preview
-
-      # global.json dynamically generate (use latest SDK available)
-      - name: Force .NET 11 SDK via global.json
-        run: |
-          $sdkVersion = (dotnet --list-sdks | Select-String "11.0").ToString().Split(" ")[0]
-          if (-not $sdkVersion) {
-            # Fallback to .NET 10 if .NET 11 is not available
-            $sdkVersion = (dotnet --list-sdks | Select-String "10.0").ToString().Split(" ")[0]
-          }
-          Write-Output "Using SDK $sdkVersion"
-          @"
-          {
-            "sdk": {
-              "version": "$sdkVersion",
-              "rollForward": "latestFeature"
-            }
-          }
-          "@ | Out-File -Encoding utf8 global.json
-
       - name: Print diagnostics
         shell: pwsh
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Checkout Standard-Toolkit
         run: git clone --depth 1 --branch alpha https://github.com/Krypton-Suite/Standard-Toolkit.git ../Standard-Toolkit
 
+      # Stable SDKs only — do not request loose 11.0.x (resolves to preview and breaks mixed TFM builds).
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v6
         with:
@@ -40,12 +41,9 @@ jobs:
             8.0.x
             6.0.x
 
-      # Required for net11.0-windows TFMs (Directory.Build.props). Preview until .NET 11 RTM.
-      - name: Setup .NET 11
-        uses: actions/setup-dotnet@v6
-        with:
-          dotnet-version: 11.0.x
-          dotnet-quality: preview
+      # Put Visual Studio MSBuild on PATH (preferred for mixed .NET Framework + SDK-style solutions).
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
 
       - name: Print diagnostics
         shell: pwsh
@@ -59,12 +57,29 @@ jobs:
           }
 
       # Use the non-NuGet solution so projects use ProjectReference to Standard-Toolkit (no Krypton.Standard.Toolkit package on nuget.org)
-      - name: Restore using dotnet
-        run: dotnet restore "Source/Krypton Toolkit/Krypton Toolkit Suite Extended 2022 - VS2022.sln"
-
-      - name: Build solution using dotnet
+      - name: Restore solution (MSBuild if available)
+        shell: pwsh
         run: |
-          dotnet build "Source/Krypton Toolkit/Krypton Toolkit Suite Extended 2022 - VS2022.sln" -c ${{ matrix.configuration }} -p:Platform="Any CPU" -v minimal --no-restore
+          $sln = "Source/Krypton Toolkit/Krypton Toolkit Suite Extended 2022 - VS2022.sln"
+          if (Get-Command msbuild -ErrorAction SilentlyContinue) {
+            Write-Output "Using msbuild to restore"
+            msbuild $sln -t:Restore
+          } else {
+            Write-Output "msbuild not found — falling back to dotnet restore"
+            dotnet restore $sln
+          }
+
+      - name: Build solution (MSBuild if available)
+        shell: pwsh
+        run: |
+          $sln = "Source/Krypton Toolkit/Krypton Toolkit Suite Extended 2022 - VS2022.sln"
+          if (Get-Command msbuild -ErrorAction SilentlyContinue) {
+            Write-Output "Using msbuild to build solution"
+            msbuild $sln /m /p:Configuration=${{ matrix.configuration }} /p:Platform="Any CPU" /verbosity:minimal
+          } else {
+            Write-Output "msbuild not found — falling back to dotnet build"
+            dotnet build $sln -c ${{ matrix.configuration }} -p:Platform="Any CPU" -v minimal --no-restore
+          }
 
       - name: Upload build artifacts
         if: matrix.configuration != 'Debug'
@@ -74,4 +89,3 @@ jobs:
           path: |
             Bin/${{ matrix.configuration }}/
           retention-days: 7
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,10 @@ jobs:
         with:
           fetch-depth: 0  # Full history for versioning
 
+      # Extended-Toolkit project refs expect Standard-Toolkit as sibling (..\Standard-Toolkit)
+      - name: Checkout Standard-Toolkit
+        run: git clone --depth 1 https://github.com/Krypton-Suite/Standard-Toolkit.git ../Standard-Toolkit
+
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,10 @@ jobs:
         with:
           fetch-depth: 0  # Full history for versioning
 
-      # Extended-Toolkit project refs expect Standard-Toolkit as sibling (..\Standard-Toolkit)
+      # Extended-Toolkit V110 project refs expect Standard-Toolkit alpha as sibling (..\Standard-Toolkit).
+      # master still uses Krypton.Utilities; alpha renamed it to Krypton.Toolkit.Utilities.
       - name: Checkout Standard-Toolkit
-        run: git clone --depth 1 https://github.com/Krypton-Suite/Standard-Toolkit.git ../Standard-Toolkit
+        run: git clone --depth 1 --branch alpha https://github.com/Krypton-Suite/Standard-Toolkit.git ../Standard-Toolkit
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   build-and-release:
     name: Build and Release Toolkit
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     
     steps:
       - name: Checkout repository
@@ -70,11 +70,15 @@ jobs:
           "@ | Out-File -Encoding utf8 global.json
 
       - name: Print diagnostics
+        shell: pwsh
         run: |
           dotnet --list-sdks
           dotnet --info
-          $msbuild = Get-ChildItem "C:\Program Files\Microsoft Visual Studio\2022\*\MSBuild\Current\Bin\MSBuild.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
-          if ($msbuild) { & $msbuild.FullName -version } else { msbuild -version 2>$null; if (-not $?) { Write-Output "msbuild not found (using dotnet build instead)" } }
+          if (Get-Command msbuild -ErrorAction SilentlyContinue) {
+            msbuild -version
+          } else {
+            Write-Output "msbuild not found (using dotnet build instead)"
+          }
 
       - name: Determine Configuration
         id: config

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,31 +48,6 @@ jobs:
             9.0.x
             8.0.x
             6.0.x
-          # continue-on-error: true
-
-      # .NET 11 (Preview)
-      - name: Setup .NET 11 (Preview)
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: 11.0.x
-          dotnet-quality: preview
-
-      - name: Force .NET 11 SDK via global.json  # global.json dynamically generated
-        run: |
-          $sdkVersion = (dotnet --list-sdks | Select-String "11.0").ToString().Split(" ")[0]
-          if (-not $sdkVersion) {
-            # Fallback to .NET 10 if .NET 11 is not available
-            $sdkVersion = (dotnet --list-sdks | Select-String "10.0").ToString().Split(" ")[0]
-          }
-          Write-Output "Using SDK $sdkVersion"
-          @"
-          {
-            "sdk": {
-              "version": "$sdkVersion",
-              "rollForward": "latestFeature"
-            }
-          }
-          "@ | Out-File -Encoding utf8 global.json
 
       - name: Print diagnostics
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,13 +41,20 @@ jobs:
         run: git clone --depth 1 --branch alpha https://github.com/Krypton-Suite/Standard-Toolkit.git ../Standard-Toolkit
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: |
             10.0.x
             9.0.x
             8.0.x
             6.0.x
+
+      # Required for net11.0-windows TFMs (Directory.Build.props). Preview until .NET 11 RTM.
+      - name: Setup .NET 11
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: 11.0.x
+          dotnet-quality: preview
 
       - name: Print diagnostics
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,8 @@ jobs:
         run: |
           dotnet --list-sdks
           dotnet --info
-          & 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe' -version || msbuild -version || Write-Output "msbuild not found"
+          $msbuild = Get-ChildItem "C:\Program Files\Microsoft Visual Studio\2022\*\MSBuild\Current\Bin\MSBuild.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+          if ($msbuild) { & $msbuild.FullName -version } else { msbuild -version 2>$null; if (-not $?) { Write-Output "msbuild not found (using dotnet build instead)" } }
 
       - name: Determine Configuration
         id: config

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Checkout Standard-Toolkit
         run: git clone --depth 1 --branch alpha https://github.com/Krypton-Suite/Standard-Toolkit.git ../Standard-Toolkit
 
+      # Stable SDKs only — do not request loose 11.0.x (resolves to preview and breaks mixed TFM builds).
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v6
         with:
@@ -49,12 +50,9 @@ jobs:
             8.0.x
             6.0.x
 
-      # Required for net11.0-windows TFMs (Directory.Build.props). Preview until .NET 11 RTM.
-      - name: Setup .NET 11
-        uses: actions/setup-dotnet@v6
-        with:
-          dotnet-version: 11.0.x
-          dotnet-quality: preview
+      # Put Visual Studio MSBuild on PATH (preferred for mixed .NET Framework + SDK-style solutions).
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
 
       - name: Print diagnostics
         shell: pwsh
@@ -80,19 +78,55 @@ jobs:
           echo "configuration=$config" >> $env:GITHUB_OUTPUT
           echo "Building with configuration: $config"
 
-      - name: Restore using dotnet (Main Solution)
-        run: dotnet restore "Source/Krypton Toolkit/Krypton Toolkit Suite Extended 2022 - VS2022.sln"
-
-      - name: Build Main Solution using dotnet
+      - name: Restore Main Solution (MSBuild if available)
+        shell: pwsh
         run: |
-          dotnet build "Source/Krypton Toolkit/Krypton Toolkit Suite Extended 2022 - VS2022.sln" -c ${{ steps.config.outputs.configuration }} -p:Platform="Any CPU" -v minimal --no-restore
+          $sln = "Source/Krypton Toolkit/Krypton Toolkit Suite Extended 2022 - VS2022.sln"
+          if (Get-Command msbuild -ErrorAction SilentlyContinue) {
+            Write-Output "Using msbuild to restore"
+            msbuild $sln -t:Restore
+          } else {
+            Write-Output "msbuild not found — falling back to dotnet restore"
+            dotnet restore $sln
+          }
 
-      - name: Restore using dotnet (NuGet Solution)
-        run: dotnet restore "Source/Krypton Toolkit/Krypton Toolkit Suite Extended 2022 - VS2022 - NuGet.sln"
-
-      - name: Build NuGet Solution using dotnet
+      - name: Build Main Solution (MSBuild if available)
+        shell: pwsh
         run: |
-          dotnet build "Source/Krypton Toolkit/Krypton Toolkit Suite Extended 2022 - VS2022 - NuGet.sln" -c ${{ steps.config.outputs.configuration }} -p:Platform="Any CPU" -v minimal --no-restore
+          $sln = "Source/Krypton Toolkit/Krypton Toolkit Suite Extended 2022 - VS2022.sln"
+          $config = "${{ steps.config.outputs.configuration }}"
+          if (Get-Command msbuild -ErrorAction SilentlyContinue) {
+            Write-Output "Using msbuild to build solution"
+            msbuild $sln /m /p:Configuration=$config /p:Platform="Any CPU" /verbosity:minimal
+          } else {
+            Write-Output "msbuild not found — falling back to dotnet build"
+            dotnet build $sln -c $config -p:Platform="Any CPU" -v minimal --no-restore
+          }
+
+      - name: Restore NuGet Solution (MSBuild if available)
+        shell: pwsh
+        run: |
+          $sln = "Source/Krypton Toolkit/Krypton Toolkit Suite Extended 2022 - VS2022 - NuGet.sln"
+          if (Get-Command msbuild -ErrorAction SilentlyContinue) {
+            Write-Output "Using msbuild to restore"
+            msbuild $sln -t:Restore
+          } else {
+            Write-Output "msbuild not found — falling back to dotnet restore"
+            dotnet restore $sln
+          }
+
+      - name: Build NuGet Solution (MSBuild if available)
+        shell: pwsh
+        run: |
+          $sln = "Source/Krypton Toolkit/Krypton Toolkit Suite Extended 2022 - VS2022 - NuGet.sln"
+          $config = "${{ steps.config.outputs.configuration }}"
+          if (Get-Command msbuild -ErrorAction SilentlyContinue) {
+            Write-Output "Using msbuild to build solution"
+            msbuild $sln /m /p:Configuration=$config /p:Platform="Any CPU" /verbosity:minimal
+          } else {
+            Write-Output "msbuild not found — falling back to dotnet build"
+            dotnet build $sln -c $config -p:Platform="Any CPU" -v minimal --no-restore
+          }
 
       - name: Build and Pack Ultimate Packages
         shell: pwsh

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -165,4 +165,16 @@
 	 <PropertyGroup>
 		 <ForceDesignerDPIUnaware>true</ForceDesignerDPIUnaware>
 	 </PropertyGroup>
+
+	 <!--
+		 MSB3822/MSB3823: binary .resx (images/icons) require preserialized GenerateResource +
+		 System.Resources.Extensions (especially on .NET Framework TFMs with modern SDKs).
+	 -->
+	 <PropertyGroup>
+		 <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
+	 </PropertyGroup>
+
+	 <ItemGroup>
+		 <PackageReference Include="System.Resources.Extensions" Version="9.0.10" />
+	 </ItemGroup>
 </Project>

--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -6,6 +6,7 @@
 
 ## 2026-11-xx - Build 2611 - November 2026
 
+* Resolved GitHub build workflows
 * Resolved [#533](https://github.com/Krypton-Suite/Extended-Toolkit/issues/533), TreeGridView: Plus/Minus Sign Not Displayed in TreeGrid and Collapse/Expand Behaviors Broken
 * New `Krypton.Toolkit.Suite.Extended.BottomSheet` module - Material-inspired bottom sheets for WinForms
   - **Service API** - `KryptonBottomSheetManager` with `Open`, `OpenAsync`, `OpenNonModal`, and `DismissActive`; `KryptonBottomSheetRef` for `Dismiss()`, `AfterOpened`, `AfterDismissed`, and `AfterDismissedAsync()`

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Error.Reporting/Components/Network/Senders/ExceptionReporterWebClient.cs
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Error.Reporting/Components/Network/Senders/ExceptionReporterWebClient.cs
@@ -25,6 +25,7 @@
  */
 #endregion
 
+using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
 using System.Threading;

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Error.Reporting/Globals/GlobalDeclarations.cs
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Error.Reporting/Globals/GlobalDeclarations.cs
@@ -35,6 +35,7 @@ global using System.Globalization;
 global using System.IO;
 global using System.Management;
 global using System.Net;
+global using System.Net.Http;
 global using System.Net.Mail;
 global using System.Reflection;
 global using System.Runtime.Serialization;

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Global.Utilities/Krypton.Toolkit.Suite.Extended.Global.Utilities 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Global.Utilities/Krypton.Toolkit.Suite.Extended.Global.Utilities 2022.csproj
@@ -111,6 +111,11 @@
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 
+	<ItemGroup Condition="'$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net48' Or '$(TargetFramework)' == 'net481'">
+		<!-- System.Net.Http is not referenced by default for .NET Framework in SDK-style projects -->
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
+	</ItemGroup>
+
 	<ItemGroup>
 		<ProjectReference Include="..\Krypton.Toolkit.Suite.Extended.Debug.Tools\Krypton.Toolkit.Suite.Extended.Debug.Tools 2022.csproj" />
 		<ProjectReference Include="..\Krypton.Toolkit.Suite.Extended.Developer.Utilities\Krypton.Toolkit.Suite.Extended.Developer.Utilities 2022.csproj" />

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Messagebox/Globals/GlobalStaticConstants.cs
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Messagebox/Globals/GlobalStaticConstants.cs
@@ -1,0 +1,41 @@
+#region MIT License
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017 - 2026 Krypton Suite
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit.Suite.Extended.Messagebox;
+
+/// <summary>
+/// Shared constant values used by the extended message box.
+/// Mirrors the Standard Toolkit V110 <c>GlobalStaticConstants</c> members consumed here.
+/// </summary>
+internal static class GlobalStaticConstants
+{
+    /// <summary>Padding used for button spacing in message boxes.</summary>
+    public const int GLOBAL_BUTTON_PADDING = 10;
+
+    /// <summary>Default primary corner rounding value for controls.</summary>
+    public const float DEFAULT_PRIMARY_CORNER_ROUNDING_VALUE = -1f;
+}

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Messagebox/Globals/GlobalStaticVariables.cs
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Messagebox/Globals/GlobalStaticVariables.cs
@@ -1,0 +1,38 @@
+#region MIT License
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017 - 2026 Krypton Suite
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit.Suite.Extended.Messagebox;
+
+/// <summary>
+/// Shared static values used by the extended message box.
+/// Mirrors the Standard Toolkit V110 <c>GlobalStaticVariables</c> members consumed here.
+/// </summary>
+internal static class GlobalStaticVariables
+{
+    /// <summary>The major version of the operating system.</summary>
+    public static readonly int OS_MAJOR_VERSION = Environment.OSVersion.Version.Major;
+}

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Software.Updater.Core/Krypton.Toolkit.Suite.Extended.Software.Updater.Core 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Software.Updater.Core/Krypton.Toolkit.Suite.Extended.Software.Updater.Core 2022.csproj
@@ -118,6 +118,11 @@
 		<!--<PackageReference Include="NSec.Cryptography" Version="23.5.0-preview.1" />-->
 	</ItemGroup>
 
+	<ItemGroup Condition="'$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net48' Or '$(TargetFramework)' == 'net481'">
+		<!-- System.Net.Http is not referenced by default for .NET Framework in SDK-style projects -->
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
+	</ItemGroup>
+
 	<ItemGroup>
 		<ProjectReference Include="..\Krypton.Toolkit.Suite.Extended.Developer.Utilities\Krypton.Toolkit.Suite.Extended.Developer.Utilities 2022.csproj" />
 	</ItemGroup>

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Software.Updater.Core/NetSparkle/Downloaders/WebClientFileDownloader.cs
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Software.Updater.Core/NetSparkle/Downloaders/WebClientFileDownloader.cs
@@ -25,6 +25,8 @@
 
 #endregion
 
+using System.Net.Http;
+
 namespace Krypton.Toolkit.Suite.Extended.Software.Updater.Core;
 
 /// <summary>

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Software.Updater.Core/NetSparkle/Downloaders/WebRequestAppCastDataDownloader.cs
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Software.Updater.Core/NetSparkle/Downloaders/WebRequestAppCastDataDownloader.cs
@@ -24,6 +24,8 @@
 
 #endregion
 
+using System.Net.Http;
+
 namespace Krypton.Toolkit.Suite.Extended.Software.Updater.Core;
 
 /// <summary>

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Software.Updater.Core/NetSparkle/Miscellaneous/ReleaseNotesGrabber.cs
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Software.Updater.Core/NetSparkle/Miscellaneous/ReleaseNotesGrabber.cs
@@ -24,6 +24,8 @@
 
 #endregion
 
+using System.Net.Http;
+
 namespace Krypton.Toolkit.Suite.Extended.Software.Updater.Core;
 
 /// <summary>

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Software.Updater/ILRepack.targets
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Software.Updater/ILRepack.targets
@@ -1,0 +1,41 @@
+<Project>
+	<!--
+		Override the default ILRepack.Lib.MSBuild.Task target.
+		PresentationFramework is a shared-framework assembly on net8+ (not a discrete mergeable DLL),
+		so only ILRepack .NET Framework outputs.
+	-->
+	<Target Name="ILRepack"
+			AfterTargets="Build"
+			Condition="$(Configuration.Contains('Release')) and $(TargetFramework.StartsWith('net4')) and '$(IsCrossTargetingBuild)' != 'true'">
+		<PropertyGroup>
+			<_ILRepackKeyFile Condition="'$(_ILRepackKeyFile)' == ''">$(AssemblyOriginatorKeyFile)</_ILRepackKeyFile>
+			<_ILRepackKeyFile Condition="'$(_ILRepackKeyFile)' == ''">$(KeyFile)</_ILRepackKeyFile>
+		</PropertyGroup>
+
+		<ItemGroup>
+			<InputAssemblies Include="$(OutputPath)$(TargetName)$(TargetExt)" />
+			<InputAssemblies Include="$(OutputPath)*.dll" Exclude="$(OutputPath)$(TargetName)$(TargetExt)" />
+		</ItemGroup>
+
+		<ILRepack Parallel="true"
+				  DebugInfo="true"
+				  AllowDuplicateResources="false"
+				  InputAssemblies="@(InputAssemblies)"
+				  TargetKind="SameAsPrimaryAssembly"
+				  KeyFile="$(_ILRepackKeyFile)"
+				  OutputFile="$(OutputPath)$(TargetName)$(TargetExt)" />
+	</Target>
+
+	<Target Name="CleanReferenceCopyLocalPaths"
+			AfterTargets="ILRepack"
+			Condition="$(Configuration.Contains('Release')) and $(TargetFramework.StartsWith('net4')) and '$(ClearOutputDirectory)' != 'False' and '$(IsCrossTargetingBuild)' != 'true'">
+		<Delete Files="@(ReferenceCopyLocalPaths->'$(OutDir)%(DestinationSubDirectory)%(Filename)%(Extension)')" />
+		<ItemGroup>
+			<Directories Include="$([System.IO.Directory]::GetDirectories('$(OutDir)%(DestinationSubDirectory)', '*', System.IO.SearchOption.AllDirectories))" />
+			<Directories>
+				<Files>$([System.IO.Directory]::GetFiles("%(Directories.Identity)", "*", System.IO.SearchOption.AllDirectories).get_Length())</Files>
+			</Directories>
+		</ItemGroup>
+		<RemoveDir Directories="@(Directories)" Condition="%(Files)=='0'" />
+	</Target>
+</Project>

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.ToastNotification/General/GlobalStaticVariables.cs
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.ToastNotification/General/GlobalStaticVariables.cs
@@ -1,0 +1,38 @@
+#region MIT License
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017 - 2026 Krypton Suite
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit.Suite.Extended.ToastNotification;
+
+/// <summary>
+/// Shared static values used by toast notifications.
+/// Mirrors the Standard Toolkit V110 <c>GlobalStaticVariables</c> members consumed here.
+/// </summary>
+internal static class GlobalStaticVariables
+{
+    /// <summary>The empty color.</summary>
+    public static readonly Color EMPTY_COLOR = Color.Empty;
+}

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.ToastNotification/GlobalUsings.cs
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.ToastNotification/GlobalUsings.cs
@@ -34,5 +34,8 @@ global using System.Drawing;
 global using System.Media;
 global using System.Windows.Forms;
 
+global using Krypton.Toolkit;
 global using Krypton.Toolkit.Suite.Extended.ToastNotification.Properties;
+// KryptonToastIcon lives in Krypton.Toolkit.Utilities (Standard Toolkit V110 / alpha),
+// which is referenced via ProjectReference (local) or Krypton.Standard.Toolkit.* (NuGet).
 global using Krypton.Toolkit.Utilities;

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.ToastNotification/Krypton.Toolkit.Suite.Extended.ToastNotification 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.ToastNotification/Krypton.Toolkit.Suite.Extended.ToastNotification 2022.csproj
@@ -96,9 +96,14 @@
 			</Choose>
 		</When>
 		<Otherwise>
+			<PropertyGroup>
+				<_StandardToolkitRoot>$(MSBuildThisFileDirectory)..\..\..\..\Standard-Toolkit\Source\Krypton Components\</_StandardToolkitRoot>
+				<_ToolkitUtilitiesCsproj>$(_StandardToolkitRoot)Krypton.Toolkit.Utilities\Krypton.Toolkit.Utilities.csproj</_ToolkitUtilitiesCsproj>
+			</PropertyGroup>
 			<ItemGroup>
-				<ProjectReference Include="..\..\..\..\Standard-Toolkit\Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />
-				<ProjectReference Include="..\..\..\..\Standard-Toolkit\Source\Krypton Components\Krypton.Toolkit.Utilities\Krypton.Toolkit.Utilities.csproj" />
+				<ProjectReference Include="$(_StandardToolkitRoot)Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />
+				<!-- V110/alpha: Krypton.Toolkit.Utilities (provides KryptonToastIcon). Not present on Standard-Toolkit master. -->
+				<ProjectReference Include="$(_ToolkitUtilitiesCsproj)" Condition="Exists('$(_ToolkitUtilitiesCsproj)')" />
 			</ItemGroup>
 		</Otherwise>
 	</Choose>

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Ultimate.Lite/Krypton.Toolkit.Suite.Extended.Ultimate.Lite 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Ultimate.Lite/Krypton.Toolkit.Suite.Extended.Ultimate.Lite 2022.csproj
@@ -83,27 +83,36 @@
 
 	<!-- Krypton Toolkit Dependencies -->
 	<Choose>
-		<When Condition="'$(Configuration)' == 'Nightly'">
-			<ItemGroup>
-				<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
-			</ItemGroup>
-		</When>
+		<When Condition="'$(SolutionName.Endswith(`NuGet`))'">
+			<Choose>
+				<When Condition="'$(Configuration)' == 'Nightly'">
+					<ItemGroup>
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+					</ItemGroup>
+				</When>
 
-		<When Condition="'$(Configuration)' == 'Canary'">
-			<ItemGroup>
-				<PackageReference Include="Krypton.Standard.Toolkit.Canary" Version="110.26.6.173-beta" />
-			</ItemGroup>
-		</When>
+				<When Condition="'$(Configuration)' == 'Canary'">
+					<ItemGroup>
+						<PackageReference Include="Krypton.Standard.Toolkit.Canary" Version="110.26.6.173-beta" />
+					</ItemGroup>
+				</When>
 
-		<When Condition="'$(Configuration)' == 'Release'">
-			<ItemGroup>
-				<PackageReference Include="Krypton.Standard.Toolkit" Version="110.26.11.328" />
-			</ItemGroup>
-		</When>
+				<When Condition="'$(Configuration)' == 'Release'">
+					<ItemGroup>
+						<PackageReference Include="Krypton.Standard.Toolkit" Version="110.26.11.328" />
+					</ItemGroup>
+				</When>
 
+				<Otherwise>
+					<ItemGroup>
+						<PackageReference Include="Krypton.Standard.Toolkit" Version="110.26.11.328" />
+					</ItemGroup>
+				</Otherwise>
+			</Choose>
+		</When>
 		<Otherwise>
 			<ItemGroup>
-				<PackageReference Include="Krypton.Standard.Toolkit" Version="110.26.11.328" />
+				<ProjectReference Include="..\..\..\..\Standard-Toolkit\Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />
 			</ItemGroup>
 		</Otherwise>
 	</Choose>

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Ultimate/Krypton.Toolkit.Suite.Extended.Ultimate 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Ultimate/Krypton.Toolkit.Suite.Extended.Ultimate 2022.csproj
@@ -80,27 +80,36 @@
 
 	<!-- Krypton Toolkit Dependencies -->
 	<Choose>
-		<When Condition="'$(Configuration)' == 'Nightly'">
-			<ItemGroup>
-				<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
-			</ItemGroup>
-		</When>
+		<When Condition="'$(SolutionName.Endswith(`NuGet`))'">
+			<Choose>
+				<When Condition="'$(Configuration)' == 'Nightly'">
+					<ItemGroup>
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+					</ItemGroup>
+				</When>
 
-		<When Condition="'$(Configuration)' == 'Canary'">
-			<ItemGroup>
-				<PackageReference Include="Krypton.Standard.Toolkit.Canary" Version="110.26.6.173-beta" />
-			</ItemGroup>
-		</When>
+				<When Condition="'$(Configuration)' == 'Canary'">
+					<ItemGroup>
+						<PackageReference Include="Krypton.Standard.Toolkit.Canary" Version="110.26.6.173-beta" />
+					</ItemGroup>
+				</When>
 
-		<When Condition="'$(Configuration)' == 'Release'">
-			<ItemGroup>
-				<PackageReference Include="Krypton.Standard.Toolkit" Version="110.26.11.328" />
-			</ItemGroup>
-		</When>
+				<When Condition="'$(Configuration)' == 'Release'">
+					<ItemGroup>
+						<PackageReference Include="Krypton.Standard.Toolkit" Version="110.26.11.328" />
+					</ItemGroup>
+				</When>
 
+				<Otherwise>
+					<ItemGroup>
+						<PackageReference Include="Krypton.Standard.Toolkit" Version="110.26.11.328" />
+					</ItemGroup>
+				</Otherwise>
+			</Choose>
+		</When>
 		<Otherwise>
 			<ItemGroup>
-				<PackageReference Include="Krypton.Standard.Toolkit" Version="110.26.11.328" />
+				<ProjectReference Include="..\..\..\..\Standard-Toolkit\Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />
 			</ItemGroup>
 		</Otherwise>
 	</Choose>

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Utilities/Globals/GlobalDeclarations.cs
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Utilities/Globals/GlobalDeclarations.cs
@@ -36,6 +36,7 @@ global using System.Diagnostics;
 global using System.Globalization;
 global using System.IO;
 global using System.Net;
+global using System.Net.Http;
 global using System.Reflection;
 global using System.Runtime.CompilerServices;
 global using System.Runtime.InteropServices;

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Utilities/Krypton.Toolkit.Suite.Extended.Utilities 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Utilities/Krypton.Toolkit.Suite.Extended.Utilities 2022.csproj
@@ -110,6 +110,11 @@
 		<OutputPath>..\..\..\Bin\$(configuration)\Krypton.Toolkit.Suite.Extended.Utilities\</OutputPath>
 		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 	</PropertyGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net48' Or '$(TargetFramework)' == 'net481'">
+		<!-- System.Net.Http is not referenced by default for .NET Framework in SDK-style projects -->
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
+	</ItemGroup>
+
 	<ItemGroup>
 		<ProjectReference Include="..\Krypton.Toolkit.Suite.Extended.Developer.Utilities\Krypton.Toolkit.Suite.Extended.Developer.Utilities 2022.csproj" />
 	</ItemGroup>


### PR DESCRIPTION
Update .github/workflows/build.yml and release.yml to more robustly locate MSBuild. Replace a hard-coded VS2022 Enterprise path with a Get-ChildItem wildcard search that selects the first MSBuild.exe found and falls back to msbuild -version. Suppresses noisy errors and emits a clearer message when MSBuild isn't found (noting dotnet build will be used). This improves support for different VS editions/paths and reduces false failures in CI logs.