### PR TITLE
* Resolve #610: Fix Ultimate packaging and dependencies

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -6,6 +6,11 @@
 
 ## 2026-11-xx - Build 2611 - November 2026
 
+* Resolved [#610](https://github.com/Krypton-Suite/Extended-Toolkit/issues/610), Error when Attempting to upgrade to Ultimate 105.26.7.201
+  - **Ultimate packaging** - Ultimate and Ultimate.Lite no longer declare Extended module packages as NuGet dependencies; assemblies are bundled with `PrivateAssets="all"` on project references
+  - **Native binaries** - Native libraries (e.g. `libSkiaSharp`) are excluded from `lib/` to avoid install failures on .NET Framework
+  - **Runtime packages** - Explicit `Handlebars.Net` and `SkiaSharp` package references retained so native assets and templates still restore correctly
+  - **Software.Updater.Core** - Corrected `PackageId` so it no longer collides with `Krypton.Toolkit.Suite.Extended.Core`
 * Resolved [#533](https://github.com/Krypton-Suite/Extended-Toolkit/issues/533), TreeGridView: Plus/Minus Sign Not Displayed in TreeGrid and Collapse/Expand Behaviors Broken
 * New `Krypton.Toolkit.Suite.Extended.BottomSheet` module - Material-inspired bottom sheets for WinForms
   - **Service API** - `KryptonBottomSheetManager` with `Open`, `OpenAsync`, `OpenNonModal`, and `DismissActive`; `KryptonBottomSheetRef` for `Dismiss()`, `AfterOpened`, `AfterDismissed`, and `AfterDismissedAsync()`

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.AdvancedDataGridView/Krypton.Toolkit.Suite.Extended.AdvancedDataGridView 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.AdvancedDataGridView/Krypton.Toolkit.Suite.Extended.AdvancedDataGridView 2022.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.BottomSheet/Krypton.Toolkit.Suite.Extended.BottomSheet.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.BottomSheet/Krypton.Toolkit.Suite.Extended.BottomSheet.csproj
@@ -72,7 +72,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Buttons/Krypton.Toolkit.Suite.Extended.Buttons 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Buttons/Krypton.Toolkit.Suite.Extended.Buttons 2022.csproj
@@ -72,7 +72,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Calendar/Krypton.Toolkit.Suite.Extended.Calendar 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Calendar/Krypton.Toolkit.Suite.Extended.Calendar 2022.csproj
@@ -72,7 +72,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Card/Krypton.Toolkit.Suite.Extended.Card.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Card/Krypton.Toolkit.Suite.Extended.Card.csproj
@@ -72,7 +72,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.CheckSum.Tools/Krypton.Toolkit.Suite.Extended.CheckSum.Tools 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.CheckSum.Tools/Krypton.Toolkit.Suite.Extended.CheckSum.Tools 2022.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Circular.ProgressBar/Krypton.Toolkit.Suite.Extended.Circular.ProgressBar 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Circular.ProgressBar/Krypton.Toolkit.Suite.Extended.Circular.ProgressBar 2022.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.ComboBox/Krypton.Toolkit.Suite.Extended.ComboBox 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.ComboBox/Krypton.Toolkit.Suite.Extended.ComboBox 2022.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Common/Krypton.Toolkit.Suite.Extended.Common 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Common/Krypton.Toolkit.Suite.Extended.Common 2022.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Compression/Krypton.Toolkit.Suite.Extended.Compression 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Compression/Krypton.Toolkit.Suite.Extended.Compression 2022.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Controls/Krypton.Toolkit.Suite.Extended.Controls 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Controls/Krypton.Toolkit.Suite.Extended.Controls 2022.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Core/Krypton.Toolkit.Suite.Extended.Core 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Core/Krypton.Toolkit.Suite.Extended.Core 2022.csproj
@@ -73,7 +73,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Data.Visualisation/Krypton.Toolkit.Suite.Extended.Data.Visualisation 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Data.Visualisation/Krypton.Toolkit.Suite.Extended.Data.Visualisation 2022.csproj
@@ -77,7 +77,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.DataGridView/Krypton.Toolkit.Suite.Extended.DataGridView 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.DataGridView/Krypton.Toolkit.Suite.Extended.DataGridView 2022.csproj
@@ -75,7 +75,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Debug.Tools/Krypton.Toolkit.Suite.Extended.Debug.Tools 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Debug.Tools/Krypton.Toolkit.Suite.Extended.Debug.Tools 2022.csproj
@@ -73,7 +73,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Developer.Utilities/Krypton.Toolkit.Suite.Extended.Developer.Utilities 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Developer.Utilities/Krypton.Toolkit.Suite.Extended.Developer.Utilities 2022.csproj
@@ -73,7 +73,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Dialogs/Krypton.Toolkit.Suite.Extended.Dialogs 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Dialogs/Krypton.Toolkit.Suite.Extended.Dialogs 2022.csproj
@@ -76,7 +76,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Dock.Extender/Krypton.Toolkit.Suite.Extended.Dock.Extender 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Dock.Extender/Krypton.Toolkit.Suite.Extended.Dock.Extender 2022.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Drawing.Utilities/Krypton.Toolkit.Suite.Extended.Drawing.Utilities 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Drawing.Utilities/Krypton.Toolkit.Suite.Extended.Drawing.Utilities 2022.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Drawing/Krypton.Toolkit.Suite.Extended.Drawing 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Drawing/Krypton.Toolkit.Suite.Extended.Drawing 2022.csproj
@@ -73,7 +73,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Effects/Krypton.Toolkit.Suite.Extended.Effects 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Effects/Krypton.Toolkit.Suite.Extended.Effects 2022.csproj
@@ -73,7 +73,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Error.Reporting/Krypton.Toolkit.Suite.Extended.Error.Reporting 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Error.Reporting/Krypton.Toolkit.Suite.Extended.Error.Reporting 2022.csproj
@@ -76,7 +76,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.File.Copier/Krypton.Toolkit.Suite.Extended.File.Copier 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.File.Copier/Krypton.Toolkit.Suite.Extended.File.Copier 2022.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Floating.Toolbars/Krypton.Toolkit.Suite.Extended.Floating.Toolbars 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Floating.Toolbars/Krypton.Toolkit.Suite.Extended.Floating.Toolbars 2022.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Forms/Krypton.Toolkit.Suite.Extended.Forms 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Forms/Krypton.Toolkit.Suite.Extended.Forms 2022.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.GanttChart/Krypton.Toolkit.Suite.Extended.GanttChart.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.GanttChart/Krypton.Toolkit.Suite.Extended.GanttChart.csproj
@@ -77,7 +77,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Global.Utilities/Krypton.Toolkit.Suite.Extended.Global.Utilities 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Global.Utilities/Krypton.Toolkit.Suite.Extended.Global.Utilities 2022.csproj
@@ -73,7 +73,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.IO/Krypton.Toolkit.Suite.Extended.IO 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.IO/Krypton.Toolkit.Suite.Extended.IO 2022.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.InputBox/Krypton.Toolkit.Suite.Extended.InputBox 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.InputBox/Krypton.Toolkit.Suite.Extended.InputBox 2022.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Language.Model/Krypton.Toolkit.Suite.Extended.Language.Model 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Language.Model/Krypton.Toolkit.Suite.Extended.Language.Model 2022.csproj
@@ -73,7 +73,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Memory.Box/Krypton.Toolkit.Suite.Extended.Memory.Box 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Memory.Box/Krypton.Toolkit.Suite.Extended.Memory.Box 2022.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.MessageDialog/Krypton.Toolkit.Suite.Extended.MessageDialog.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.MessageDialog/Krypton.Toolkit.Suite.Extended.MessageDialog.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Messagebox/Krypton.Toolkit.Suite.Extended.Messagebox 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Messagebox/Krypton.Toolkit.Suite.Extended.Messagebox 2022.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Navi.Suite/Krypton.Toolkit.Suite.Extended.Navi.Suite 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Navi.Suite/Krypton.Toolkit.Suite.Extended.Navi.Suite 2022.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Navigator/Krypton.Toolkit.Suite.Extended.Navigator 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Navigator/Krypton.Toolkit.Suite.Extended.Navigator 2022.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Networking/Krypton.Toolkit.Suite.Extended.Networking 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Networking/Krypton.Toolkit.Suite.Extended.Networking 2022.csproj
@@ -76,7 +76,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Notifications/Krypton.Toolkit.Suite.Extended.Notifications 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Notifications/Krypton.Toolkit.Suite.Extended.Notifications 2022.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Outlook.Grid/Krypton.Toolkit.Suite.Extended.Outlook.Grid 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Outlook.Grid/Krypton.Toolkit.Suite.Extended.Outlook.Grid 2022.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Panels/Krypton.Toolkit.Suite.Extended.Panels 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Panels/Krypton.Toolkit.Suite.Extended.Panels 2022.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Resources/Krypton.Toolkit.Suite.Extended.Resources 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Resources/Krypton.Toolkit.Suite.Extended.Resources 2022.csproj
@@ -73,7 +73,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Ribbon/Krypton.Toolkit.Suite.Extended.Ribbon 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Ribbon/Krypton.Toolkit.Suite.Extended.Ribbon 2022.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Security/Krypton.Toolkit.Suite.Extended.Security 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Security/Krypton.Toolkit.Suite.Extended.Security 2022.csproj
@@ -72,7 +72,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Settings/Krypton.Toolkit.Suite.Extended.Settings 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Settings/Krypton.Toolkit.Suite.Extended.Settings 2022.csproj
@@ -73,7 +73,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Shared/Krypton.Toolkit.Suite.Extended.Shared 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Shared/Krypton.Toolkit.Suite.Extended.Shared 2022.csproj
@@ -73,7 +73,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Software.Updater.Core/Krypton.Toolkit.Suite.Extended.Software.Updater.Core 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Software.Updater.Core/Krypton.Toolkit.Suite.Extended.Software.Updater.Core 2022.csproj
@@ -35,33 +35,33 @@
 	<Choose>
 		<When Condition="'$(Configuration)' == 'Canary'">
 			<PropertyGroup>
-				<PackageId>Krypton.Toolkit.Suite.Extended.Core.Canary</PackageId>
+				<PackageId>Krypton.Toolkit.Suite.Extended.Software.Updater.Core.Canary</PackageId>
 			</PropertyGroup>
 		</When>
 
 		<When Condition="'$(Configuration)' == 'Nightly'">
 			<PropertyGroup>
-				<PackageId>Krypton.Toolkit.Suite.Extended.Core.Nightly</PackageId>
+				<PackageId>Krypton.Toolkit.Suite.Extended.Software.Updater.Core.Nightly</PackageId>
 			</PropertyGroup>
 		</When>
 
 		<When Condition="'$(Configuration)' == 'Release'">
 			<PropertyGroup>
-				<PackageId>Krypton.Toolkit.Suite.Extended.Core</PackageId>
+				<PackageId>Krypton.Toolkit.Suite.Extended.Software.Updater.Core</PackageId>
 			</PropertyGroup>
 		</When>
 		<Otherwise>
 			<PropertyGroup>
-				<PackageId>Krypton.Toolkit.Suite.Extended.Core</PackageId>
+				<PackageId>Krypton.Toolkit.Suite.Extended.Software.Updater.Core</PackageId>
 			</PropertyGroup>
 		</Otherwise>
 	</Choose>
 
 	<PropertyGroup>
 		<Description>
-			An extension to the Standard Toolkit, which supports .NET Framework 4.6.2 - 4.8.1, .NET 8 - 10. This package implements core utilities that are fundamental to the extended toolkit.
+			An extension to the Standard Toolkit, which supports .NET Framework 4.7.2 - 4.8.1, .NET 8 - 10. This package implements software updater core utilities for the extended toolkit.
 
-			This package supports all .NET Framework versions starting .NET Framework 4.6.2 - 4.8.1, .NET 8 - 10.
+			This package supports all .NET Framework versions starting .NET Framework 4.7.2 - 4.8.1, .NET 8 - 10.
 			Also, all libraries are included targeting each specific framework version for performance purposes.
 
 			To view all of the extended toolkit package latest version information, please visit: https://github.com/Krypton-Suite/Krypton-Toolkit-Suite-Version-Dashboard/blob/main/Documents/Modules/Extended/Krypton-Toolkit-Suite-Extended-Modules.md
@@ -73,7 +73,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Software.Updater/Krypton.Toolkit.Suite.Extended.Software.Updater 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Software.Updater/Krypton.Toolkit.Suite.Extended.Software.Updater 2022.csproj
@@ -76,7 +76,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Specialised.Dialogs/Krypton.Toolkit.Suite.Extended.Specialised.Dialogs 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Specialised.Dialogs/Krypton.Toolkit.Suite.Extended.Specialised.Dialogs 2022.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Theme.Switcher/Krypton.Toolkit.Suite.Extended.Theme.Switcher 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Theme.Switcher/Krypton.Toolkit.Suite.Extended.Theme.Switcher 2022.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.ToastNotification/Krypton.Toolkit.Suite.Extended.ToastNotification 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.ToastNotification/Krypton.Toolkit.Suite.Extended.ToastNotification 2022.csproj
@@ -72,7 +72,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Toggle.Switch/Krypton.Toolkit.Suite.Extended.Toggle.Switch 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Toggle.Switch/Krypton.Toolkit.Suite.Extended.Toggle.Switch 2022.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Tool.Box/Krypton.Toolkit.Suite.Extended.Tool.Box 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Tool.Box/Krypton.Toolkit.Suite.Extended.Tool.Box 2022.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Tool.Strip.Items/Krypton.Toolkit.Suite.Extended.Tool.Strip.Items 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Tool.Strip.Items/Krypton.Toolkit.Suite.Extended.Tool.Strip.Items 2022.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Tools/Krypton.Toolkit.Suite.Extended.Tools 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Tools/Krypton.Toolkit.Suite.Extended.Tools 2022.csproj
@@ -71,7 +71,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.TreeGridView/Krypton.Toolkit.Suite.Extended.TreeGridView 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.TreeGridView/Krypton.Toolkit.Suite.Extended.TreeGridView 2022.csproj
@@ -77,7 +77,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Ultimate.Lite/Krypton.Toolkit.Suite.Extended.Ultimate.Lite 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Ultimate.Lite/Krypton.Toolkit.Suite.Extended.Ultimate.Lite 2022.csproj
@@ -85,7 +85,7 @@
 	<Choose>
 		<When Condition="'$(Configuration)' == 'Nightly'">
 			<ItemGroup>
-				<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+				<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 			</ItemGroup>
 		</When>
 
@@ -107,6 +107,14 @@
 			</ItemGroup>
 		</Otherwise>
 	</Choose>
+
+	<!-- Runtime packages needed by bundled modules (ProjectReferences use PrivateAssets=all). -->
+	<!-- SkiaSharp must remain a PackageReference so native assets are installed correctly. -->
+	<ItemGroup>
+		<PackageReference Include="Handlebars.Net" Version="2.1.6" />
+		<PackageReference Include="SkiaSharp" Version="4.150.1" />
+		<PackageReference Include="SkiaSharp.Views.WindowsForms" Version="4.150.1" />
+	</ItemGroup>
 
 	<!-- All Extended Toolkit Project References -->
 	<ItemGroup>
@@ -200,6 +208,11 @@
 		<ProjectReference Include="..\Krypton.Toolkit.Suite.Extended.Memory.Box\Krypton.Toolkit.Suite.Extended.Memory.Box 2022.csproj" />
 	</ItemGroup>
 
+	<!-- Bundle assemblies into this package; do not emit Extended modules as NuGet dependencies (#610). -->
+	<ItemGroup>
+		<ProjectReference Update="@(ProjectReference)" PrivateAssets="all" />
+	</ItemGroup>
+
 	<!-- Package Assets -->
 	<!-- Note: README.md and icons are handled centrally in Directory.Build.props -->
 	<!-- Ultimate projects use a different license file location -->
@@ -219,7 +232,8 @@
 		<!-- Force inclusion of all dependencies -->
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 		<IncludeBuildOutput>true</IncludeBuildOutput>
-		<IncludeReferencedProjects>true</IncludeReferencedProjects>
+		<!-- Project refs use PrivateAssets=all; assemblies are packed via IncludeAllDependenciesInPackage -->
+		<IncludeReferencedProjects>false</IncludeReferencedProjects>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		
@@ -233,64 +247,20 @@
 		<TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);IncludeAllDependenciesInPackage</TargetsForTfmSpecificContentInPackage>
 	</PropertyGroup>
 
-	<!-- Custom target to include ALL dependencies in the package -->
+	<!-- Bundle managed dependency assemblies; exclude framework + native binaries from lib/ -->
 	<Target Name="IncludeAllDependenciesInPackage" DependsOnTargets="ResolveReferences">
 		<ItemGroup>
-			<!-- Include ONLY non-framework assemblies (exclude System.*, Microsoft.VisualBasic.*, mscorlib, netstandard, WindowsBase, etc.) -->
 			<_AllReferences Include="@(ReferenceCopyLocalPaths)" />
 			
-			<!-- Filter out framework assemblies -->
-			<_FrameworkAssemblies Include="@(_AllReferences)" Condition="$([System.String]::new('%(Filename)').StartsWith('System.')) OR &#xD;&#xA;         $([System.String]::new('%(Filename)').StartsWith('Microsoft.VisualBasic')) OR &#xD;&#xA;         $([System.String]::new('%(Filename)').StartsWith('Microsoft.Win32.')) OR &#xD;&#xA;         $([System.String]::new('%(Filename)').StartsWith('Microsoft.CSharp')) OR &#xD;&#xA;         '%(Filename)' == 'mscorlib' OR &#xD;&#xA;         '%(Filename)' == 'netstandard' OR &#xD;&#xA;         '%(Filename)' == 'WindowsBase' OR &#xD;&#xA;         '%(Filename)' == 'PresentationCore' OR &#xD;&#xA;         '%(Filename)' == 'PresentationFramework' OR &#xD;&#xA;         $([System.String]::new('%(Filename)').StartsWith('PresentationFramework.')) OR &#xD;&#xA;         '%(Filename)' == 'PresentationUI' OR &#xD;&#xA;         '%(Filename)' == 'ReachFramework' OR &#xD;&#xA;         '%(Filename)' == 'UIAutomationClient' OR &#xD;&#xA;         '%(Filename)' == 'UIAutomationClientSideProviders' OR &#xD;&#xA;         '%(Filename)' == 'UIAutomationProvider' OR &#xD;&#xA;         '%(Filename)' == 'UIAutomationTypes' OR &#xD;&#xA;         '%(Filename)' == 'Accessibility'" />
+			<_ExcludedFromPackageLib Include="@(_AllReferences)" Condition="'%(Extension)' != '.dll' OR &#xD;&#xA;         $([System.String]::new('%(Filename)').StartsWith('System.')) OR &#xD;&#xA;         $([System.String]::new('%(Filename)').StartsWith('Microsoft.VisualBasic')) OR &#xD;&#xA;         $([System.String]::new('%(Filename)').StartsWith('Microsoft.Win32.')) OR &#xD;&#xA;         $([System.String]::new('%(Filename)').StartsWith('Microsoft.CSharp')) OR &#xD;&#xA;         $([System.String]::new('%(Filename)').StartsWith('lib')) OR &#xD;&#xA;         $([System.String]::Copy('%(Identity)').Contains('\native\')) OR &#xD;&#xA;         $([System.String]::Copy('%(Identity)').Contains('/native/')) OR &#xD;&#xA;         '%(Filename)' == 'mscorlib' OR &#xD;&#xA;         '%(Filename)' == 'netstandard' OR &#xD;&#xA;         '%(Filename)' == 'WindowsBase' OR &#xD;&#xA;         '%(Filename)' == 'PresentationCore' OR &#xD;&#xA;         '%(Filename)' == 'PresentationFramework' OR &#xD;&#xA;         $([System.String]::new('%(Filename)').StartsWith('PresentationFramework.')) OR &#xD;&#xA;         '%(Filename)' == 'PresentationUI' OR &#xD;&#xA;         '%(Filename)' == 'ReachFramework' OR &#xD;&#xA;         '%(Filename)' == 'UIAutomationClient' OR &#xD;&#xA;         '%(Filename)' == 'UIAutomationClientSideProviders' OR &#xD;&#xA;         '%(Filename)' == 'UIAutomationProvider' OR &#xD;&#xA;         '%(Filename)' == 'UIAutomationTypes' OR &#xD;&#xA;         '%(Filename)' == 'Accessibility' OR &#xD;&#xA;         '%(Filename)' == 'e_sqlite3'" />
 			
-			<!-- Include only non-framework assemblies -->
-			<_NonFrameworkAssemblies Include="@(_AllReferences)" Exclude="@(_FrameworkAssemblies)" />
+			<_ManagedAssembliesForPackage Include="@(_AllReferences)" Exclude="@(_ExcludedFromPackageLib)" />
 			
-			<BuildOutputInPackage Include="@(_NonFrameworkAssemblies)" />
-			<TfmSpecificPackageFile Include="@(_NonFrameworkAssemblies)" PackagePath="lib/$(_PackageLibTfm)/" />
+			<BuildOutputInPackage Include="@(_ManagedAssembliesForPackage)" />
+			<TfmSpecificPackageFile Include="@(_ManagedAssembliesForPackage)" PackagePath="lib/$(_PackageLibTfm)/" />
 		</ItemGroup>
 		
 		<Message Text="Including %(TfmSpecificPackageFile.Identity) in package" Importance="low" />
-	</Target>
-	
-
-	<!-- Extended Toolkit Package Dependencies -->
-	<!-- These are added dynamically during pack operations to satisfy NuGet dependency resolution -->
-	<!-- IncludeAssets="none" and PrivateAssets="All" prevent NuGet from downloading these packages -->
-	<!-- The DLLs are already embedded via ProjectReferences -->
-	<!-- Only add these during pack operations (not during restore/build) to avoid version resolution errors -->
-	<!-- Skip during restore by checking if Restore target is running -->
-	<Target Name="AddExtendedToolkitPackageReferencesForPack" BeforeTargets="GenerateNuspec" Condition="'$(IsRestoring)' != 'true' AND ('$(IsPackaging)' == 'true' OR '$(GeneratePackageOnBuild)' == 'true')">
-		<ItemGroup>
-			<!-- Core & Foundation - Required by other packages -->
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Core" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Release'" />
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Core.Nightly" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Nightly'" />
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Core.Canary" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Canary'" />
-			
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Common" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Release'" />
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Common.Nightly" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Nightly'" />
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Common.Canary" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Canary'" />
-			
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Shared" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Release'" />
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Shared.Nightly" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Nightly'" />
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Shared.Canary" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Canary'" />
-			
-			<!-- Packages mentioned in the error that require Core -->
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Buttons" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Release'" />
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Buttons.Nightly" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Nightly'" />
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Buttons.Canary" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Canary'" />
-			
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Data.Visualisation" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Release'" />
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Data.Visualisation.Nightly" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Nightly'" />
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Data.Visualisation.Canary" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Canary'" />
-			
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Drawing.Utilities" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Release'" />
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Drawing.Utilities.Nightly" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Nightly'" />
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Drawing.Utilities.Canary" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Canary'" />
-			
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Language.Model" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Release'" />
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Language.Model.Nightly" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Nightly'" />
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Language.Model.Canary" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Canary'" />
-		</ItemGroup>
 	</Target>
 
 	<!-- Note: UltimateLitePackageInfo.cs is automatically included by the SDK -->

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Ultimate/Krypton.Toolkit.Suite.Extended.Ultimate 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Ultimate/Krypton.Toolkit.Suite.Extended.Ultimate 2022.csproj
@@ -82,7 +82,7 @@
 	<Choose>
 		<When Condition="'$(Configuration)' == 'Nightly'">
 			<ItemGroup>
-				<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+				<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 			</ItemGroup>
 		</When>
 
@@ -104,6 +104,14 @@
 			</ItemGroup>
 		</Otherwise>
 	</Choose>
+
+	<!-- Runtime packages needed by bundled modules (ProjectReferences use PrivateAssets=all). -->
+	<!-- SkiaSharp must remain a PackageReference so native assets are installed correctly. -->
+	<ItemGroup>
+		<PackageReference Include="Handlebars.Net" Version="2.1.6" />
+		<PackageReference Include="SkiaSharp" Version="4.150.1" />
+		<PackageReference Include="SkiaSharp.Views.WindowsForms" Version="4.150.1" />
+	</ItemGroup>
 
 	<!-- All Extended Toolkit Project References -->
 	<ItemGroup>
@@ -197,6 +205,11 @@
 		<ProjectReference Include="..\Krypton.Toolkit.Suite.Extended.Memory.Box\Krypton.Toolkit.Suite.Extended.Memory.Box 2022.csproj" />
 	</ItemGroup>
 
+	<!-- Bundle assemblies into this package; do not emit Extended modules as NuGet dependencies (#610). -->
+	<ItemGroup>
+		<ProjectReference Update="@(ProjectReference)" PrivateAssets="all" />
+	</ItemGroup>
+
 	<!-- Package Assets -->
 	<!-- Note: README.md and icons are handled centrally in Directory.Build.props -->
 	<!-- Ultimate projects use a different license file location -->
@@ -216,7 +229,8 @@
 		<!-- Force inclusion of all dependencies -->
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 		<IncludeBuildOutput>true</IncludeBuildOutput>
-		<IncludeReferencedProjects>true</IncludeReferencedProjects>
+		<!-- Project refs use PrivateAssets=all; assemblies are packed via IncludeAllDependenciesInPackage -->
+		<IncludeReferencedProjects>false</IncludeReferencedProjects>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		
@@ -230,64 +244,20 @@
 		<TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);IncludeAllDependenciesInPackage</TargetsForTfmSpecificContentInPackage>
 	</PropertyGroup>
 
-	<!-- Custom target to include ALL dependencies in the package -->
+	<!-- Bundle managed dependency assemblies; exclude framework + native binaries from lib/ -->
 	<Target Name="IncludeAllDependenciesInPackage" DependsOnTargets="ResolveReferences">
 		<ItemGroup>
-			<!-- Include ONLY non-framework assemblies (exclude System.*, Microsoft.VisualBasic.*, mscorlib, netstandard, WindowsBase, etc.) -->
 			<_AllReferences Include="@(ReferenceCopyLocalPaths)" />
 			
-			<!-- Filter out framework assemblies -->
-			<_FrameworkAssemblies Include="@(_AllReferences)" Condition="$([System.String]::new('%(Filename)').StartsWith('System.')) OR &#xD;&#xA;         $([System.String]::new('%(Filename)').StartsWith('Microsoft.VisualBasic')) OR &#xD;&#xA;         $([System.String]::new('%(Filename)').StartsWith('Microsoft.Win32.')) OR &#xD;&#xA;         $([System.String]::new('%(Filename)').StartsWith('Microsoft.CSharp')) OR &#xD;&#xA;         '%(Filename)' == 'mscorlib' OR &#xD;&#xA;         '%(Filename)' == 'netstandard' OR &#xD;&#xA;         '%(Filename)' == 'WindowsBase' OR &#xD;&#xA;         '%(Filename)' == 'PresentationCore' OR &#xD;&#xA;         '%(Filename)' == 'PresentationFramework' OR &#xD;&#xA;         $([System.String]::new('%(Filename)').StartsWith('PresentationFramework.')) OR &#xD;&#xA;         '%(Filename)' == 'PresentationUI' OR &#xD;&#xA;         '%(Filename)' == 'ReachFramework' OR &#xD;&#xA;         '%(Filename)' == 'UIAutomationClient' OR &#xD;&#xA;         '%(Filename)' == 'UIAutomationClientSideProviders' OR &#xD;&#xA;         '%(Filename)' == 'UIAutomationProvider' OR &#xD;&#xA;         '%(Filename)' == 'UIAutomationTypes' OR &#xD;&#xA;         '%(Filename)' == 'Accessibility'" />
+			<_ExcludedFromPackageLib Include="@(_AllReferences)" Condition="'%(Extension)' != '.dll' OR &#xD;&#xA;         $([System.String]::new('%(Filename)').StartsWith('System.')) OR &#xD;&#xA;         $([System.String]::new('%(Filename)').StartsWith('Microsoft.VisualBasic')) OR &#xD;&#xA;         $([System.String]::new('%(Filename)').StartsWith('Microsoft.Win32.')) OR &#xD;&#xA;         $([System.String]::new('%(Filename)').StartsWith('Microsoft.CSharp')) OR &#xD;&#xA;         $([System.String]::new('%(Filename)').StartsWith('lib')) OR &#xD;&#xA;         $([System.String]::Copy('%(Identity)').Contains('\native\')) OR &#xD;&#xA;         $([System.String]::Copy('%(Identity)').Contains('/native/')) OR &#xD;&#xA;         '%(Filename)' == 'mscorlib' OR &#xD;&#xA;         '%(Filename)' == 'netstandard' OR &#xD;&#xA;         '%(Filename)' == 'WindowsBase' OR &#xD;&#xA;         '%(Filename)' == 'PresentationCore' OR &#xD;&#xA;         '%(Filename)' == 'PresentationFramework' OR &#xD;&#xA;         $([System.String]::new('%(Filename)').StartsWith('PresentationFramework.')) OR &#xD;&#xA;         '%(Filename)' == 'PresentationUI' OR &#xD;&#xA;         '%(Filename)' == 'ReachFramework' OR &#xD;&#xA;         '%(Filename)' == 'UIAutomationClient' OR &#xD;&#xA;         '%(Filename)' == 'UIAutomationClientSideProviders' OR &#xD;&#xA;         '%(Filename)' == 'UIAutomationProvider' OR &#xD;&#xA;         '%(Filename)' == 'UIAutomationTypes' OR &#xD;&#xA;         '%(Filename)' == 'Accessibility' OR &#xD;&#xA;         '%(Filename)' == 'e_sqlite3'" />
 			
-			<!-- Include only non-framework assemblies -->
-			<_NonFrameworkAssemblies Include="@(_AllReferences)" Exclude="@(_FrameworkAssemblies)" />
+			<_ManagedAssembliesForPackage Include="@(_AllReferences)" Exclude="@(_ExcludedFromPackageLib)" />
 			
-			<BuildOutputInPackage Include="@(_NonFrameworkAssemblies)" />
-			<TfmSpecificPackageFile Include="@(_NonFrameworkAssemblies)" PackagePath="lib/$(_PackageLibTfm)/" />
+			<BuildOutputInPackage Include="@(_ManagedAssembliesForPackage)" />
+			<TfmSpecificPackageFile Include="@(_ManagedAssembliesForPackage)" PackagePath="lib/$(_PackageLibTfm)/" />
 		</ItemGroup>
 		
 		<Message Text="Including %(TfmSpecificPackageFile.Identity) in package" Importance="low" />
-	</Target>
-	
-
-	<!-- Extended Toolkit Package Dependencies -->
-	<!-- These are added dynamically during pack operations to satisfy NuGet dependency resolution -->
-	<!-- IncludeAssets="none" and PrivateAssets="All" prevent NuGet from downloading these packages -->
-	<!-- The DLLs are already embedded via ProjectReferences -->
-	<!-- Only add these during pack operations (not during restore/build) to avoid version resolution errors -->
-	<!-- Skip during restore by checking if Restore target is running -->
-	<Target Name="AddExtendedToolkitPackageReferencesForPack" BeforeTargets="GenerateNuspec" Condition="'$(IsRestoring)' != 'true' AND ('$(IsPackaging)' == 'true' OR '$(GeneratePackageOnBuild)' == 'true')">
-		<ItemGroup>
-			<!-- Core & Foundation - Required by other packages -->
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Core" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Release'" />
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Core.Nightly" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Nightly'" />
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Core.Canary" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Canary'" />
-			
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Common" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Release'" />
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Common.Nightly" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Nightly'" />
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Common.Canary" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Canary'" />
-			
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Shared" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Release'" />
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Shared.Nightly" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Nightly'" />
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Shared.Canary" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Canary'" />
-			
-			<!-- Packages mentioned in the error that require Core -->
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Buttons" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Release'" />
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Buttons.Nightly" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Nightly'" />
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Buttons.Canary" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Canary'" />
-			
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Data.Visualisation" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Release'" />
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Data.Visualisation.Nightly" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Nightly'" />
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Data.Visualisation.Canary" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Canary'" />
-			
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Drawing.Utilities" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Release'" />
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Drawing.Utilities.Nightly" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Nightly'" />
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Drawing.Utilities.Canary" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Canary'" />
-			
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Language.Model" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Release'" />
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Language.Model.Nightly" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Nightly'" />
-			<PackageReference Include="Krypton.Toolkit.Suite.Extended.Language.Model.Canary" Version="$(PackageVersion)" IncludeAssets="none" PrivateAssets="All" Condition="'$(Configuration)' == 'Canary'" />
-		</ItemGroup>
 	</Target>
 
 	<!-- Note: UltimatePackageInfo.cs is automatically included by the SDK -->

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Utilities/Krypton.Toolkit.Suite.Extended.Utilities 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Utilities/Krypton.Toolkit.Suite.Extended.Utilities 2022.csproj
@@ -75,7 +75,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.VirtualTreeColumnView/Krypton.Toolkit.Suite.Extended.VirtualTreeColumnView 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.VirtualTreeColumnView/Krypton.Toolkit.Suite.Extended.VirtualTreeColumnView 2022.csproj
@@ -78,7 +78,7 @@
             <Choose>
                 <When Condition="'$(Configuration)' == 'Nightly'">
                     <ItemGroup>
-                        <PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+                        <PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
                     </ItemGroup>
                 </When>
 

--- a/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Wizard/Krypton.Toolkit.Suite.Extended.Wizard 2022.csproj
+++ b/Source/Krypton Toolkit/Krypton.Toolkit.Suite.Extended.Wizard/Krypton.Toolkit.Suite.Extended.Wizard 2022.csproj
@@ -74,7 +74,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 

--- a/Source/Krypton Toolkit/ZipExtractor/ZipExtractor.csproj
+++ b/Source/Krypton Toolkit/ZipExtractor/ZipExtractor.csproj
@@ -18,7 +18,7 @@
 			<Choose>
 				<When Condition="'$(Configuration)' == 'Nightly'">
 					<ItemGroup>
-						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.200-alpha" />
+						<PackageReference Include="Krypton.Standard.Toolkit.Nightly" Version="110.26.7.207-alpha" />
 					</ItemGroup>
 				</When>
 


### PR DESCRIPTION
Fixes issue #610 by restructuring Ultimate and Ultimate.Lite packaging to bundle Extended modules with PrivateAssets=all instead of declaring them as NuGet dependencies. Also excludes native binaries (e.g., libSkiaSharp) from lib/ to prevent install failures on .NET Framework, retains explicit Handlebars.Net and SkiaSharp package references for proper asset restoration, and corrects Software.Updater.Core PackageId to prevent collision with Core module. Updates Krypton.Standard.Toolkit.Nightly dependency to 110.26.7.207-alpha.